### PR TITLE
fix: complete remaining GitHub code scanning security fixes

### DIFF
--- a/tests/test_cross_platform_integration.py
+++ b/tests/test_cross_platform_integration.py
@@ -437,7 +437,7 @@ class TestPlatformSpecificEdgeCases:
         if platform.system() != "Windows":
             readonly_dir = tmp_path / "readonly"
             readonly_dir.mkdir()
-            os.chmod(readonly_dir, 0o444)  # Read-only
+            os.chmod(readonly_dir, 0o400)  # Read-only for owner only
 
             try:
                 with SevenZipFile(archive_path, "r") as sz, pytest.raises(

--- a/tests/test_pypi_version_validation.py
+++ b/tests/test_pypi_version_validation.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+import py7zz
 from py7zz.core import get_version
 from py7zz.version import parse_version
 
@@ -314,8 +315,6 @@ class TestUserInstallationExperience:
         assert import_version == core_version
 
         # Test that version is accessible from main package
-        import py7zz
-
         assert hasattr(py7zz, "get_version")
 
     def test_version_upgrade_path(self):


### PR DESCRIPTION
## Summary

This PR completes the remaining GitHub code scanning security fixes that were addressed after the initial PR #17 was merged. These additional fixes resolve the final code scanning alerts.

## Additional Changes Made

### 🔵 Import Style Consistency 
- **Fixed mixed import styles** in `tests/test_pypi_version_validation.py` - Moved local `import py7zz` to module level to eliminate mixed import pattern warning

### 🔴 File Permission Security
- **Tightened test file permissions** in `tests/test_cross_platform_integration.py` - Changed `0o444` (world readable) to `0o400` (owner read-only) to eliminate overly permissive file warning

## Security Impact

- **Eliminates remaining "overly permissive file" warnings** - Further restricts test file permissions
- **Resolves import style consistency issues** - Improves code maintainability and eliminates scanner warnings

## Test Plan

✅ **All quality checks passed:**
- Affected tests continue to pass with new permissions
- Import functionality maintained with cleaner structure
- All code quality checks pass (ruff, mypy)
- Local CI simulation successful

## Compatibility

- ✅ **Fully backward compatible** - No breaking changes
- ✅ **Test functionality preserved** - All tests continue to work as expected
- ✅ **Zero functional impact** - Only security and style improvements

This PR ensures all GitHub Advanced Security code scanning alerts are fully resolved.

Closes remaining code scanning alerts from the initial security review.