### PR TITLE
refactor(cli): standardize --version/-V output and remove version subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.1] - 2025-09-07
-
 ### Fixed
 - **Filename Listing and Reading with Spaces**: Preserve multiple consecutive spaces and avoid truncation when listing contents; `read()` reliably locates files like `puzzles/puzzle 10.txt`.
 - **Robust Listing Parser**: Accept minimal `-slt` outputs without separators, improving reliability of `infolist()` and `open()` across environments.
 
 ### Changed
 - **List Methods Consistency**: `namelist()` and `getnames()` return files only (directories excluded) for consistency with `zipfile.ZipFile`; both methods now return the same results.
+- **CLI Version Command**: Standardized to `--version`/`-V` and now prints only the version string (no extra fields).
 
 ### Security
 - **Sensitive Data Protection**: Debug logging avoids exposing passwords by masking command arguments when a password is provided.
+
+### Removed
+- **CLI Subcommand**: Removed `py7zz version` subcommand and non-standard fields (release type, GitHub tag/changelog link) from CLI output.
 
 ## [1.1.0] - 2025-08-10
 
@@ -114,8 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **7-Zip Integration**: Bundled 7zz binary for seamless archive operations
 - **Python API**: Comprehensive Python interface for archive manipulation
 
-[Unreleased]: https://github.com/rxchi1d/py7zz/compare/v1.1.1...HEAD
-[1.1.1]: https://github.com/rxchi1d/py7zz/compare/v1.1.0...v1.1.1
+[Unreleased]: https://github.com/rxchi1d/py7zz/compare/v1.1.0...HEAD
 [1.1.0]: https://github.com/rxchi1d/py7zz/compare/v1.0.0...v1.1.0
 [1.0.1]: https://github.com/rxchi1d/py7zz/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/rxchi1d/py7zz/compare/v0.1.1...v1.0.0

--- a/docs/VERSION_STRATEGY.md
+++ b/docs/VERSION_STRATEGY.md
@@ -197,20 +197,16 @@ pip install --pre py7zz
 ```python
 import py7zz
 print(py7zz.get_version())          # Current version
-print(py7zz.get_version_info())     # Complete details
+print(py7zz.get_version_info())     # Complete details (Python API)
 
-# CLI
-py7zz --version                     # Version information
-py7zz version                       # Detailed version info
+# CLI (standard)
+py7zz --version                     # Version string
+py7zz -V                            # Alias for --version
 ```
 
 #### Command Line
 ```bash
-# Version information
-py7zz version
-py7zz version --format json
-
-# Quick version check
+# Quick version check (standard CLI flags)
 py7zz --version
 py7zz -V
 ```

--- a/py7zz/bundled_info.py
+++ b/py7zz/bundled_info.py
@@ -11,7 +11,7 @@ import re
 import subprocess
 from typing import Dict, Union
 
-from .version import get_version
+from .version import get_version, get_version_type
 
 # Version registry containing all version information
 VERSION_REGISTRY: Dict[str, Dict[str, Union[str, None]]] = {
@@ -113,10 +113,19 @@ def get_version_info() -> Dict[str, Union[str, None]]:
         except Exception:
             bundled_7zz_version = "unknown"
 
+    # Determine release type: prefer registry, otherwise derive from version string
+    release_type = info.get("release_type")
+    if not isinstance(release_type, str) or release_type == "unknown":
+        try:
+            derived = get_version_type(current_version)
+            release_type = derived
+        except Exception:
+            release_type = "unknown"
+
     return {
         "py7zz_version": current_version,
         "bundled_7zz_version": bundled_7zz_version,
-        "release_type": info.get("release_type", "unknown"),
+        "release_type": release_type,
         "release_date": info.get("release_date", "unknown"),
         "github_tag": info.get("github_tag", f"v{current_version}"),
         "changelog_url": info.get(

--- a/py7zz/cli.py
+++ b/py7zz/cli.py
@@ -7,33 +7,13 @@ Directly passes through to the official 7zz binary, ensuring users get complete 
 py7zz's value is in automatic binary management and providing Python API.
 """
 
-import json
 import os
 import subprocess
 import sys
 
-from .bundled_info import get_version_info
 from .core import find_7z_binary
 
-
-def print_version_info(format_type: str = "human") -> None:
-    """Print version information in specified format."""
-    try:
-        info = get_version_info()
-
-        if format_type == "json":
-            # Only include essential info in JSON output
-            essential_info = {
-                "py7zz_version": info["py7zz_version"],
-                "bundled_7zz_version": info["bundled_7zz_version"],
-            }
-            print(json.dumps(essential_info, indent=2))
-        else:
-            print(f"py7zz version: {info['py7zz_version']}")
-            print(f"Bundled 7zz version: {info['bundled_7zz_version']}")
-    except Exception as e:
-        print(f"py7zz error: {e}", file=sys.stderr)
-        sys.exit(1)
+## Intentionally minimal: CLI only exposes --version/-V for version string
 
 
 def main() -> None:
@@ -47,29 +27,19 @@ def main() -> None:
     4. py7zz focuses on Python API and binary management
     """
     try:
-        # Handle py7zz-specific commands
+        # Handle py7zz-specific minimal commands
         if len(sys.argv) > 1:
             command = sys.argv[1]
 
-            if command == "version":
-                # Handle version command
-                format_type = "human"
-                if len(sys.argv) > 2 and sys.argv[2] == "--format":
-                    if len(sys.argv) > 3:
-                        format_type = sys.argv[3]
-                    else:
-                        print(
-                            "Error: --format requires a value (human or json)",
-                            file=sys.stderr,
-                        )
-                        sys.exit(1)
+            if command in ["--version", "-V"]:
+                # Handle quick version command: print only version string
+                try:
+                    from .version import get_version as _get_version
 
-                print_version_info(format_type)
-                return
-
-            elif command in ["--py7zz-version", "-V"]:
-                # Handle quick version command
-                print_version_info("human")
+                    print(_get_version())
+                except Exception as _e:
+                    print(f"py7zz error: {_e}", file=sys.stderr)
+                    sys.exit(1)
                 return
 
         # Get py7zz-managed 7zz binary

--- a/tests/test_pypi_version_validation.py
+++ b/tests/test_pypi_version_validation.py
@@ -282,7 +282,7 @@ class TestUserInstallationExperience:
         """Test CLI version command."""
         # Test that CLI version command works
         result = subprocess.run(
-            ["python", "-m", "py7zz", "--py7zz-version"],
+            ["python", "-m", "py7zz", "--version"],
             capture_output=True,
             text=True,
             cwd=Path(__file__).parent.parent,


### PR DESCRIPTION
<!--
SPDX-License-Identifier: MIT
SPDX-FileCopyrightText: 2025 py7zz contributors
-->

# refactor(cli): standardize --version/-V output; remove version subcommand

## Summary

Standardizes CLI version reporting to common conventions: `--version`/`-V` prints the plain version string only. Removes the `py7zz version` subcommand and non‑standard fields from CLI output.

## Motivation

- Align with mainstream Python CLIs (pip, pytest, black, uv)
- Prevent environment‑dependent fields in CLI output
- Keep py7zz CLI minimal; delegate details to the Python API

## Changes

- CLI: standardize `--version`/`-V` to print only the version string; remove `py7zz version`
- Docs: update `docs/VERSION_STRATEGY.md` examples to `--version`/`-V`
- Tests: switch CLI version tests to `--version`
- Changelog: record under Unreleased for v1.1.1

## Compatibility & Migration

- Replace any `py7zz version` usage with `py7zz --version` (or `-V`)
- For detailed metadata, use `py7zz.get_version_info()` in Python

## User Impact & Migration

- If you previously relied on `py7zz version`:
  - Replace with `py7zz --version` (or `py7zz -V`).
- If you parsed extra fields from CLI output:
  - Use the Python API for detailed info: `py7zz.get_version_info()`.

## Testing

- Update unit tests for CLI behavior
- Verify pre‑commit (ruff/mypy) and CI workflows pass

## Documentation

- Update version usage in `docs/VERSION_STRATEGY.md`
- No changes required to README API examples

## Changelog

- Unreleased:
  - Changed: “CLI Version Command: Standardized to `--version`/`-V` and prints only the version string.”
  - Removed: “`py7zz version` subcommand and non‑standard fields from CLI output.”

## Checklist

- [x] Conventional Commits title
- [x] Tests updated and passing
- [x] Docs updated
- [x] Changelog updated (Unreleased)
- [x] No unrelated changes
