### PR TITLE
feat: add native ARM64 wheel support for Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,17 @@ jobs:
           # macOS: test intermediate version for additional platform validation
           - os: macos-latest
             python-version: "3.11"
+          # Linux ARM64: sampled coverage (minimum and maximum supported)
+          - os: ubuntu-24.04-arm
+            python-version: "3.8"
+          - os: ubuntu-24.04-arm
+            python-version: "3.13"
+          # Windows ARM64: sampled coverage. Native Windows ARM64 Python exists
+          # only for 3.11+, so the minimum sample is 3.11 instead of 3.8.
+          - os: windows-11-arm
+            python-version: "3.11"
+          - os: windows-11-arm
+            python-version: "3.13"
       fail-fast: false
 
     steps:
@@ -80,10 +91,33 @@ jobs:
         version: "latest"
         enable-cache: true
 
-    - name: Set up Python ${{ matrix.python-version }}
+    # Reason: windows-11-arm has no uv-managed native ARM64 Python builds via the
+    # default path used historically, so use actions/setup-python (native ARM64,
+    # Python 3.11+) and point uv at that system interpreter. All other runners
+    # keep the uv-managed Python install.
+    - name: Set up Python ${{ matrix.python-version }} (setup-python, ARM64)
+      if: matrix.os == 'windows-11-arm'
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set up Python ${{ matrix.python-version }} (uv-managed)
+      if: matrix.os != 'windows-11-arm'
       run: uv python install ${{ matrix.python-version }}
 
+    # Reason: export via GITHUB_ENV so every subsequent uv invocation (sync,
+    # pytest, mypy) binds to the native ARM64 setup-python interpreter; per-step
+    # env would leave later 'uv run' steps free to resolve a different one.
+    - name: Configure uv to use system Python (windows-11-arm)
+      if: matrix.os == 'windows-11-arm'
+      shell: bash
+      run: |
+        echo "UV_PYTHON_PREFERENCE=only-system" >> "$GITHUB_ENV"
+        echo "UV_PYTHON_DOWNLOADS=never" >> "$GITHUB_ENV"
+        echo "UV_PYTHON=${pythonLocation}/python.exe" >> "$GITHUB_ENV"
+
     - name: Install dependencies
+      shell: bash
       run: |
         uv sync --dev
         uv pip install -e .
@@ -91,131 +125,52 @@ jobs:
     - name: Download 7zz binary for testing
       shell: bash
       run: |
-        # Use locked version from file
-        echo "Reading configured 7-Zip version..."
+        # Reason: download logic now has a single source of truth in get_7zz.sh.
+        # Platform/arch are passed explicitly from runner.os/runner.arch instead
+        # of relying on the script's uname-based auto-detection: on windows-11-arm
+        # the Git Bash toolchain is x64-emulated and 'uname -m' reports x86_64,
+        # which would silently download the x64 binary and fake the ARM coverage.
+        case "${{ runner.os }}" in
+          Linux)   OS_ARG="linux" ;;
+          Windows) OS_ARG="windows" ;;
+          macOS)   OS_ARG="macos" ;;
+          *) echo "Unsupported runner OS: ${{ runner.os }}"; exit 1 ;;
+        esac
+        if [[ "$OS_ARG" == "macos" ]]; then
+          ARCH_ARG="universal2"
+        elif [[ "${{ runner.arch }}" == "ARM64" ]]; then
+          ARCH_ARG="arm64"
+        else
+          ARCH_ARG="x86_64"
+        fi
+
         chmod +x scripts/get_7zz.sh
-        VERSION=$(./scripts/get_7zz.sh --get-current)
-        echo "Configured version: $VERSION"
-        VERSION_FOR_ASSET=$(echo "$VERSION" | sed 's/\.//g')  # e.g., 25.01 -> 2501
+        ./scripts/get_7zz.sh --os "$OS_ARG" --arch "$ARCH_ARG"
 
-        # Map platform to 7zz release naming (same logic as release.yml)
+        # Short fatal verification: the binary must exist and be runnable.
         if [[ "${{ runner.os }}" == "Windows" ]]; then
-          ASSET_NAME="7z${VERSION_FOR_ASSET}-x64.exe"
-          BINARY_NAME="7zz.exe"
-        elif [[ "${{ runner.os }}" == "macOS" ]]; then
-          ASSET_NAME="7z${VERSION_FOR_ASSET}-mac.tar.xz"
-          BINARY_NAME="7zz"
+          BINARY_PATH="py7zz/bin/7zz.exe"
+          HELP_FLAG="-h"
         else
-          ASSET_NAME="7z${VERSION_FOR_ASSET}-linux-x64.tar.xz"
-          BINARY_NAME="7zz"
+          BINARY_PATH="py7zz/bin/7zz"
+          HELP_FLAG="--help"
         fi
 
-        DOWNLOAD_URL="https://github.com/ip7z/7zip/releases/download/${VERSION}/${ASSET_NAME}"
-        echo "Downloading from: $DOWNLOAD_URL"
-
-        TEMP_DIR=$(mktemp -d)
-        curl -L -o "${TEMP_DIR}/${ASSET_NAME}" "$DOWNLOAD_URL"
-
-        if [[ "${{ runner.os }}" == "Windows" ]]; then
-          # Windows installer - extract CLI components (same logic as release.yml)
-          echo "Downloading installer and extracting CLI components..."
-          echo "URL: $DOWNLOAD_URL"
-
-          # Create binary directory for testing
-          mkdir -p "py7zz/bin"
-
-          # GitHub Runner has built-in 7z.exe for extraction
-          7z x "${TEMP_DIR}/${ASSET_NAME}" -o"${TEMP_DIR}/out" > /dev/null
-
-          # Extract complete CLI with DLL for full format support (7z.exe + 7z.dll)
-          if [[ -f "${TEMP_DIR}/out/7z.exe" ]] && [[ -f "${TEMP_DIR}/out/7z.dll" ]]; then
-            # Rename 7z.exe to 7zz.exe for cross-platform consistency
-            cp "${TEMP_DIR}/out/7z.exe" "py7zz/bin/${BINARY_NAME}"
-            cp "${TEMP_DIR}/out/7z.dll" "py7zz/bin/"
-            echo "Windows CLI components (7z.exe + 7z.dll) extracted and copied successfully"
-          else
-            echo "Error: 7z.exe or 7z.dll not found in extracted files"
-            echo "Contents of extracted directory:"
-            ls -la "${TEMP_DIR}/out/"
-            exit 1
-          fi
-        else
-          # Unix tar.xz file (same logic as release.yml)
-          echo "Downloading and extracting Unix binary..."
-          echo "URL: $DOWNLOAD_URL"
-
-          # Create binary directory for testing
-          mkdir -p "py7zz/bin"
-
-          cd "${TEMP_DIR}"
-          tar -xf "${ASSET_NAME}"
-
-          # Find and copy the 7zz binary (search only in current extraction directory)
-          BINARY_PATH=$(find . -name "7zz" -type f | head -1)
-          if [ -n "$BINARY_PATH" ]; then
-            cp "$BINARY_PATH" "$GITHUB_WORKSPACE/py7zz/bin/${BINARY_NAME}"
-            echo "Binary found and copied: $BINARY_PATH -> py7zz/bin/${BINARY_NAME}"
-
-            # Return to workspace directory to set permissions
-            cd "$GITHUB_WORKSPACE"
-
-            # Make binary executable for Unix systems
-            if [[ "${{ runner.os }}" != "Windows" ]]; then
-              chmod +x "py7zz/bin/${BINARY_NAME}"
-              echo "Set executable permissions for Unix binary"
-            fi
-          else
-            echo "Error: 7zz binary not found in extracted files"
-            echo "Contents of extracted directory:"
-            ls -la .
-            exit 1
-          fi
-        fi
-
-        # Ensure we're in the workspace directory for verification
-        cd "$GITHUB_WORKSPACE"
-
-        # Verify the binary was placed correctly (same logic as release.yml)
-        echo "Verifying binary placement..."
-        if [[ -f "py7zz/bin/${BINARY_NAME}" ]]; then
-          echo "✓ Binary correctly placed at: py7zz/bin/${BINARY_NAME}"
-          ls -la "py7zz/bin/"
-        else
-          echo "✗ Binary not found at expected location: py7zz/bin/${BINARY_NAME}"
-          echo "Contents of py7zz/bin/:"
-          find py7zz/bin/ -type f -ls || echo "No files found"
+        if [[ ! -f "$BINARY_PATH" ]]; then
+          echo "Error: 7zz binary not found at $BINARY_PATH"
           exit 1
         fi
 
-        # Verify binary works (same logic as release.yml)
-        echo "Verifying binary functionality..."
-        BINARY_PATH="py7zz/bin/${BINARY_NAME}"
-
-        if [[ "${{ runner.os }}" == "Windows" ]]; then
-          # Windows binary verification - verify 7zz.exe (from 7z.exe) with 7z.dll works
-          if "$BINARY_PATH" -h > /dev/null 2>&1; then
-            echo "✓ Windows binary verification passed - 7zz.exe (from 7z.exe) with full format support"
-          else
-            echo "✗ Windows binary cannot run properly"
-            echo "Binary path: $BINARY_PATH"
-            echo "Binary exists: $(test -f "$BINARY_PATH" && echo "yes" || echo "no")"
-            echo "DLL exists: $(test -f "py7zz/bin/7z.dll" && echo "yes" || echo "no")"
-            echo "Binary size: $(stat -c%s "$BINARY_PATH" 2>/dev/null || stat -f%z "$BINARY_PATH" 2>/dev/null || echo "unknown")"
-            exit 1
-          fi
-        else
-          # Unix binary verification
-          if "$BINARY_PATH" --help > /dev/null 2>&1; then
-            echo "✓ Unix binary verification passed"
-          else
-            echo "✗ Unix binary verification failed for: $BINARY_PATH"
-            exit 1
-          fi
+        if [[ "${{ runner.os }}" == "Windows" ]] && [[ ! -f "py7zz/bin/7z.dll" ]]; then
+          echo "Error: 7z.dll not found alongside the Windows binary"
+          exit 1
         fi
 
-        # Clean up
-        cd "$GITHUB_WORKSPACE"
-        rm -rf "${TEMP_DIR}"
+        if ! "$BINARY_PATH" "$HELP_FLAG" > /dev/null 2>&1; then
+          echo "Error: 7zz binary at $BINARY_PATH failed to run"
+          exit 1
+        fi
+        echo "7zz binary verified at $BINARY_PATH"
 
     - name: Run pytest
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,15 @@ jobs:
             platform: linux
             arch: x86_64
             binary_name: 7zz
-            wheel_tag: manylinux1_x86_64
+            # Reason: corrected from manylinux1 (glibc 2.17 floor, verified below
+            # before publish). Dual tag: PEP 600 form for modern pip (>=20.3) plus
+            # the legacy manylinux2014 alias so pip 19.3-20.2 still accepts the wheel.
+            wheel_tag: manylinux_2_17_x86_64.manylinux2014_x86_64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+            binary_name: 7zz
+            wheel_tag: manylinux_2_17_aarch64.manylinux2014_aarch64
           - os: macos-latest  # Universal2 runner
             platform: macos
             arch: universal2
@@ -29,6 +37,11 @@ jobs:
             arch: x86_64
             binary_name: 7zz.exe
             wheel_tag: win_amd64
+          - os: windows-11-arm
+            platform: windows
+            arch: arm64
+            binary_name: 7zz.exe
+            wheel_tag: win_arm64
 
     steps:
     - uses: actions/checkout@v4
@@ -73,7 +86,29 @@ jobs:
         version: "latest"  # Use latest version for better lock file support
       timeout-minutes: 3  # Add timeout to prevent hanging
 
+    # Reason: windows-11-arm has no uv-managed native ARM64 Python and its
+    # pre-installed interpreter is x86_64 (emulated); actions/setup-python ships a
+    # native ARM64 build. It auto-detects arch from the host (os.arch() -> arm64),
+    # so no explicit architecture input is required.
+    - name: Set up Python (native ARM64 via setup-python)
+      if: matrix.os == 'windows-11-arm'
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    # Reason: force uv to use the setup-python interpreter on PATH and never
+    # attempt to download a managed Python, so 'uv sync --dev' / 'uv pip install'
+    # bind to the native ARM64 interpreter rather than an emulated/managed one.
+    - name: Configure uv to use system Python (windows-11-arm)
+      if: matrix.os == 'windows-11-arm'
+      shell: bash
+      run: |
+        echo "UV_PYTHON_PREFERENCE=only-system" >> "$GITHUB_ENV"
+        echo "UV_PYTHON_DOWNLOADS=never" >> "$GITHUB_ENV"
+        echo "UV_PYTHON=${pythonLocation}/python.exe" >> "$GITHUB_ENV"
+
     - name: Set up Python
+      if: matrix.os != 'windows-11-arm'
       run: uv python install 3.11
 
     - name: Validate tag format and determine release type
@@ -172,23 +207,73 @@ jobs:
           exit 1
         fi
 
-        # Test binary functionality
+        # Test binary functionality (fatal: the wheel is useless if the bundled
+        # binary cannot execute on its own native architecture)
+        # Reason: same per-platform help flag as ci.yml — the Windows binary is
+        # the renamed 7z.exe, whose canonical help switch is -h.
+        if [[ "$PLATFORM" == "windows" ]]; then
+          HELP_FLAG="-h"
+        else
+          HELP_FLAG="--help"
+        fi
         echo "Testing binary functionality..."
-        if "py7zz/bin/${BINARY_NAME}" --help > /dev/null 2>&1; then
+        if "py7zz/bin/${BINARY_NAME}" "$HELP_FLAG" > /dev/null 2>&1; then
           echo "✓ Binary functionality test passed"
         else
-          echo "✗ Binary functionality test failed"
-          echo "This may be normal for some platforms due to dependencies or signing requirements"
+          echo "✗ Binary functionality test failed - the bundled 7zz binary does not run"
+          exit 1
         fi
 
-        # For Windows, verify both 7zz.exe and 7z.dll are present
+        # For Windows, both 7zz.exe and 7z.dll are required (fatal if missing:
+        # 7z.dll backs archive-format support and the wheel ships incomplete without it)
         if [[ "$PLATFORM" == "windows" ]]; then
           if [[ -f "py7zz/bin/7z.dll" ]]; then
             echo "✓ Windows 7z.dll found for complete functionality"
           else
-            echo "⚠️ Windows 7z.dll not found - some formats may not be supported"
+            echo "✗ Windows 7z.dll not found - aborting build"
+            exit 1
           fi
         fi
+
+    # Reason: the manylinux2014 wheel tag promises the bundled binary requires at
+    # most GLIBC 2.17. This step backs that tag with evidence by measuring the
+    # binary's actual maximum required GLIBC symbol version and failing the build
+    # if it exceeds the floor, preventing a mislabeled wheel from reaching PyPI.
+    - name: Verify glibc floor for manylinux2014 (linux rows only)
+      if: matrix.platform == 'linux'
+      shell: bash
+      run: |
+        BINARY="py7zz/bin/${{ matrix.binary_name }}"
+        FLOOR="2.17"  # glibc floor implied by the manylinux2014 wheel tag
+
+        echo "Verifying glibc floor for: $BINARY"
+
+        # Extract the maximum required GLIBC_* symbol version from the binary.
+        # sort -V (version sort) is mandatory: plain sort orders 2.14 after 2.5.
+        MAX_GLIBC=$(objdump -T "$BINARY" \
+          | grep -oP 'GLIBC_\d+\.\d+(\.\d+)?' \
+          | sort -uV \
+          | tail -1 \
+          | sed 's/^GLIBC_//')
+
+        if [ -z "$MAX_GLIBC" ]; then
+          echo "✗ Could not determine required GLIBC version from $BINARY"
+          exit 1
+        fi
+
+        echo "Maximum required GLIBC: $MAX_GLIBC (floor: $FLOOR)"
+
+        # Compare MAX_GLIBC against FLOOR using version sort. If the highest of the
+        # two is the measured value and it differs from the floor, it exceeds it.
+        HIGHEST=$(printf '%s\n%s\n' "$MAX_GLIBC" "$FLOOR" | sort -V | tail -1)
+        if [ "$HIGHEST" != "$FLOOR" ] && [ "$MAX_GLIBC" != "$FLOOR" ]; then
+          echo "✗ Binary requires GLIBC_$MAX_GLIBC which exceeds the $FLOOR floor"
+          echo "  The wheel tag '${{ matrix.wheel_tag }}' would be inaccurate."
+          echo "  Adjust the tag to the matching manylinux_2_XX value."
+          exit 1
+        fi
+
+        echo "✓ Binary GLIBC requirement is within the manylinux2014 floor"
 
     - name: Install dependencies
       timeout-minutes: 5  # Add timeout for dependency installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ARM64 Wheel Support**: Native wheels for Linux ARM64 and Windows ARM64 (Windows ARM64 requires Python 3.11+).
 - **7zz Version Detection**: Automatically tracks and reports bundled 7zz version changes in release notes.
 
 ### Changed
+- **Linux x86_64 Wheel Platform Tag**: Corrected from `manylinux1_x86_64` to `manylinux2014_x86_64`. Systems with glibc older than 2.17 are no longer offered the wheel by pip; previously, pip would install the wheel on those systems but the bundled binary would fail at runtime.
 - **Release Note Structure**: Adopted nested "Keep a Changelog" hierarchy for clearer section separation.
 - **Category Standardization**: Aligned categories with Conventional Changelog (Angular preset) standards.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **7zz Version Detection**: Automatically tracks and reports bundled 7zz version changes in release notes.
 
 ### Changed
-- **Linux x86_64 Wheel Platform Tag**: Corrected from `manylinux1_x86_64` to `manylinux2014_x86_64`. Systems with glibc older than 2.17 are no longer offered the wheel by pip; previously, pip would install the wheel on those systems but the bundled binary would fail at runtime.
+- **Linux Wheel Platform Tags**: Corrected the x86_64 wheel tag from `manylinux1_x86_64` to the dual `manylinux_2_17_x86_64.manylinux2014_x86_64` form (the new ARM64 wheel uses the matching aarch64 tags). Systems with glibc older than 2.17 are no longer offered the wheel by pip; previously, pip would install the wheel on those systems but the bundled binary would fail at runtime. Each release now verifies the bundled binary's actual glibc requirement against the wheel tag before publishing.
 - **Release Note Structure**: Adopted nested "Keep a Changelog" hierarchy for clearer section separation.
 - **Category Standardization**: Aligned categories with Conventional Changelog (Angular preset) standards.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ SPDX-FileCopyrightText: 2025 py7zz contributors
 
 ## 專案概述
 
-py7zz 是一個 Python 套件，封裝了官方的 7zz CLI 二進位檔案 (7-Zip) ，提供跨平台（macOS、Debian 系 Linux、Windows x64）提供一致的 Python API與命令接口。無需預先安裝 7-Zip，wheel 套件包含平台特定的 7zz 。
+py7zz 是一個 Python 套件，封裝了官方的 7zz CLI 二進位檔案 (7-Zip) ，跨平台（macOS Intel/Apple Silicon、Linux x86_64/ARM64、Windows x64/ARM64）提供一致的 Python API與命令接口。無需預先安裝 7-Zip，wheel 套件包含平台特定的 7zz（Windows ARM64 需 Python 3.11+）。
 
 - **Python 支援版本**：Python >= 3.8
 - **Python 套件管理工具**：uv

--- a/README.md
+++ b/README.md
@@ -313,9 +313,11 @@ mypy .
 - Python 3.8+
 - No external dependencies
 - Supported platforms:
-  - Windows x64
+  - Windows x64 / ARM64 (ARM64 requires Python 3.11+)
   - macOS (Intel & Apple Silicon)
-  - Linux x86_64
+  - Linux x86_64 / ARM64
+- Note: Windows ARM64 requires Python 3.11+ because native CPython builds for
+  Windows on ARM start at that version (python.org limitation).
 
 ## Version Information
 

--- a/py7zz/updater.py
+++ b/py7zz/updater.py
@@ -56,26 +56,41 @@ def get_platform_info() -> Tuple[str, str]:
 
 
 def get_asset_name(version: str, platform: str, arch: str) -> str:
-    """Generate the correct asset name for a given version and platform.
+    """Generate the correct asset name for a given version, platform, and architecture.
 
     Args:
-        version: 7zz version string (e.g., "24.07" or "2408")
-        platform: Platform name ("mac", "linux", "windows")
-        arch: Architecture ("x64", "arm64")
+        version: 7zz version string (e.g., "24.07" or "2408").
+        platform: Platform name ("mac", "linux", "windows").
+        arch: Architecture ("x64", "arm64").
 
     Returns:
         Asset filename for downloading from GitHub releases.
+
+    Raises:
+        UpdateError: If the platform is unsupported, or if the architecture is
+            unsupported for the given platform.
     """
     # Convert version format if needed (24.07 -> 2407)
     if "." in version:
         version = version.replace(".", "")
 
     if platform == "windows":
-        return f"7z{version}-x64.exe"
+        if arch == "x64":
+            return f"7z{version}-x64.exe"
+        elif arch == "arm64":
+            return f"7z{version}-arm64.exe"
+        else:
+            raise UpdateError(f"Unsupported Windows architecture: {arch}")
     elif platform == "mac":
+        # Reason: the official macOS archive is a universal binary covering both x64 and arm64.
         return f"7z{version}-mac.tar.xz"
     elif platform == "linux":
-        return f"7z{version}-linux-x64.tar.xz"
+        if arch == "x64":
+            return f"7z{version}-linux-x64.tar.xz"
+        elif arch == "arm64":
+            return f"7z{version}-linux-arm64.tar.xz"
+        else:
+            raise UpdateError(f"Unsupported Linux architecture: {arch}")
     else:
         raise UpdateError(f"Unsupported platform: {platform}")
 
@@ -150,7 +165,11 @@ def download_and_extract_binary(
         response.raise_for_status()
 
         if platform == "windows":
-            # Windows .exe file - direct download
+            # NOTE: the official Windows .exe asset is a 7z SFX installer, not a
+            # standalone CLI binary, so saving it as 7zz.exe yields a non-working
+            # binary. This module is currently disconnected from runtime (see
+            # core.find_7z_binary); fixing the Windows extraction is tracked for
+            # the updater-reconnection work and is intentionally out of scope here.
             with open(target_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):
                     f.write(chunk)

--- a/scripts/get_7zz.sh
+++ b/scripts/get_7zz.sh
@@ -5,7 +5,11 @@
 
 # Universal 7zz binary downloader for py7zz
 # Downloads 7zz binaries for different platforms and architectures
-# Supports: macOS (arm64, x86_64, universal2), Linux (x86_64), Windows (x64)
+# Supported combinations:
+#   macOS:   universal2 (arm64/x86_64 are accepted aliases; the universal2
+#            binary covers both)
+#   Linux:   x86_64, arm64
+#   Windows: x86_64, arm64
 
 set -euo pipefail
 
@@ -62,7 +66,8 @@ Usage: $0 [OPTIONS]
 
 Options:
   --os, --platform OS    Target OS: macos, linux, windows
-  --arch ARCH            Target architecture: universal2, x86_64
+  --arch ARCH            Target architecture: universal2, x86_64, arm64
+                         (aliases: aarch64/ARM64 -> arm64; amd64/x64 -> x86_64)
   --version VERSION      Specific 7-Zip version to download (overrides file)
   --output DIR           Output directory (default: $OUTPUT_DIR)
   --build-dir DIR        Build directory for temporary files (default: $BUILD_DIR)
@@ -77,32 +82,78 @@ Default Behavior:
   Reads version from $VERSION_FILE and downloads that version.
 
 Supported combinations:
-  macOS:   universal2 (official 7-Zip distribution supports both ARM64 and x86_64)
-  Linux:   x86_64
-  Windows: x86_64 (includes 7z.exe + 7z.dll for complete functionality)
+  macOS:   universal2 (arm64/x86_64 accepted as aliases; the universal2 binary
+           covers both architectures)
+  Linux:   x86_64, arm64
+  Windows: x86_64, arm64 (includes 7z.exe + 7z.dll for complete functionality)
 EOF
+}
+
+# Normalize an architecture string to one of: arm64, x86_64, universal2.
+#
+# Accepts the common spellings emitted by 'uname -m' and user input across
+# platforms and maps them onto py7zz's canonical names. Unknown values are
+# echoed back unchanged so callers can detect and reject them explicitly.
+#
+# Args:
+#   $1: Raw architecture string (e.g. "aarch64", "AMD64", "arm64").
+#
+# Outputs:
+#   The normalized architecture on stdout.
+normalize_arch() {
+    local raw="$1"
+    case "$raw" in
+        # Reason: 'uname -m' and CI inputs use several arm64 spellings.
+        aarch64|arm64|ARM64|Arm64) echo "arm64" ;;
+        # Reason: x86_64 appears as amd64/x64 on Windows and some toolchains.
+        x86_64|amd64|AMD64|x64|X64) echo "x86_64" ;;
+        # universal2 is a macOS-only passthrough; covers both architectures.
+        universal2) echo "universal2" ;;
+        # Unknown value: echo back unchanged so the caller can reject it.
+        *) echo "$raw" ;;
+    esac
 }
 
 # Auto-detect platform and architecture
 auto_detect_platform() {
-    local os_name=$(uname -s)
-    local arch_name=$(uname -m)
+    local os_name
+    local arch_name
+    os_name=$(uname -s)
+    arch_name=$(uname -m)
+
+    # Normalize the detected architecture up front so every branch works with
+    # py7zz's canonical names (arm64 / x86_64 / universal2).
+    local norm_arch
+    norm_arch=$(normalize_arch "$arch_name")
 
     case "$os_name" in
         Darwin)
             PLATFORM="macos"
-            ARCH="universal2"  # 7-Zip only provides universal2 for macOS
+            # 7-Zip only ships a universal2 binary for macOS; the detected
+            # architecture is irrelevant because universal2 covers both.
+            ARCH="universal2"
             ;;
         Linux)
             PLATFORM="linux"
-            case "$arch_name" in
-                x86_64) ARCH="x86_64" ;;
-                *) ARCH="x86_64" ;;  # Default fallback
+            case "$norm_arch" in
+                x86_64|arm64) ARCH="$norm_arch" ;;
+                *)
+                    # Reason: silently defaulting to x86_64 would download the
+                    # wrong binary on unsupported architectures.
+                    print_error "Unsupported Linux architecture: $arch_name"
+                    exit 1
+                    ;;
             esac
             ;;
         CYGWIN*|MINGW*|MSYS*)
             PLATFORM="windows"
-            ARCH="x64"
+            case "$norm_arch" in
+                x86_64|arm64) ARCH="$norm_arch" ;;
+                *)
+                    print_error "Unsupported Windows architecture: $arch_name"
+                    exit 1
+                    ;;
+            esac
             ;;
         *)
             print_error "Unsupported platform: $os_name"
@@ -184,21 +235,37 @@ download_macos_universal2() {
 }
 
 # Download and extract 7zz for Linux
+#
+# Args:
+#   $1: Target architecture (x86_64 or arm64).
 download_linux() {
+    local target_arch="$1"
     local version_str="${SEVEN_ZIP_VERSION//./}"
-    local url="${BASE_URL}/7z${version_str}-linux-x64.tar.xz"
-    local archive="${BUILD_DIR}/linux/7z-linux-x64.tar.xz"
-    local extract_dir="${BUILD_DIR}/linux/x86_64"
+
+    # Map py7zz's canonical architecture onto 7-Zip's asset suffix.
+    local asset_arch
+    case "$target_arch" in
+        x86_64) asset_arch="x64" ;;
+        arm64) asset_arch="arm64" ;;
+        *)
+            print_error "Unsupported Linux architecture: $target_arch"
+            return 1
+            ;;
+    esac
+
+    local url="${BASE_URL}/7z${version_str}-linux-${asset_arch}.tar.xz"
+    local archive="${BUILD_DIR}/linux/7z-linux-${asset_arch}.tar.xz"
+    local extract_dir="${BUILD_DIR}/linux/${target_arch}"
 
     mkdir -p "$extract_dir"
 
-    print_status "Downloading Linux x86_64 from: $url"
+    print_status "Downloading Linux ${target_arch} from: $url"
     if ! curl -fsSL "$url" -o "$archive"; then
-        print_error "Failed to download Linux x86_64 version"
+        print_error "Failed to download Linux ${target_arch} version"
         return 1
     fi
 
-    print_status "Extracting Linux x86_64..."
+    print_status "Extracting Linux ${target_arch}..."
     if ! tar -xf "$archive" -C "$extract_dir"; then
         print_error "Failed to extract Linux archive"
         return 1
@@ -215,21 +282,37 @@ download_linux() {
 }
 
 # Download and extract 7zz for Windows
+#
+# Args:
+#   $1: Target architecture (x86_64 or arm64).
 download_windows() {
+    local target_arch="$1"
     local version_str="${SEVEN_ZIP_VERSION//./}"
-    local url="${BASE_URL}/7z${version_str}-x64.exe"
-    local archive="${BUILD_DIR}/windows/7z-windows-x64.exe"
-    local extract_dir="${BUILD_DIR}/windows/x64"
+
+    # Map py7zz's canonical architecture onto 7-Zip's installer suffix.
+    local asset_arch
+    case "$target_arch" in
+        x86_64) asset_arch="x64" ;;
+        arm64) asset_arch="arm64" ;;
+        *)
+            print_error "Unsupported Windows architecture: $target_arch"
+            return 1
+            ;;
+    esac
+
+    local url="${BASE_URL}/7z${version_str}-${asset_arch}.exe"
+    local archive="${BUILD_DIR}/windows/7z-windows-${asset_arch}.exe"
+    local extract_dir="${BUILD_DIR}/windows/${target_arch}"
 
     mkdir -p "$extract_dir"
 
-    print_status "Downloading Windows x64 from: $url"
+    print_status "Downloading Windows ${target_arch} from: $url"
     if ! curl -fsSL "$url" -o "$archive"; then
-        print_error "Failed to download Windows x64 version"
+        print_error "Failed to download Windows ${target_arch} version"
         return 1
     fi
 
-    print_status "Extracting Windows x64..."
+    print_status "Extracting Windows ${target_arch}..."
 
     # Try different extraction methods
     if command -v 7z &> /dev/null; then
@@ -263,7 +346,10 @@ download_windows() {
     print_status "Found Windows binary: $(basename "$exe_binary")"
 
     if [ -z "$dll_file" ]; then
-        print_warning "7z.dll not found - Windows functionality may be limited"
+        # Reason: 7z.exe cannot run without 7z.dll, so a missing DLL is a hard
+        # failure rather than a warning. The caller must propagate this.
+        print_error "7z.dll not found in Windows installer - cannot continue"
+        return 1
     fi
 
     # Return both files separated by space
@@ -280,11 +366,17 @@ download_7zz() {
     rm -rf "$BUILD_DIR"
     mkdir -p "$BUILD_DIR"
 
+    # Declared here so they can be assigned separately from declaration below.
+    # Reason: 'local var=$(fn)' swallows the function's exit status, so each
+    # download result is captured on its own line to preserve set -e semantics.
+    local binary=""
+    local files=""
+
     case "$PLATFORM" in
         macos)
             case "$ARCH" in
                 universal2)
-                    local binary=$(download_macos_universal2)
+                    binary=$(download_macos_universal2)
                     if [ -z "$binary" ]; then
                         print_error "Failed to download macOS universal2 binary"
                         return 1
@@ -303,8 +395,8 @@ download_7zz() {
             ;;
         linux)
             case "$ARCH" in
-                x86_64)
-                    local binary=$(download_linux)
+                x86_64|arm64)
+                    binary=$(download_linux "$ARCH")
                     if [ -z "$binary" ]; then
                         print_error "Failed to download Linux binary"
                         return 1
@@ -323,15 +415,17 @@ download_7zz() {
             ;;
         windows)
             case "$ARCH" in
-                x86_64)
-                    local files=$(download_windows)
+                x86_64|arm64)
+                    files=$(download_windows "$ARCH")
                     if [ -z "$files" ]; then
                         print_error "Failed to download Windows files"
                         return 1
                     fi
 
-                    local exe_file=$(echo $files | cut -d' ' -f1)
-                    local dll_file=$(echo $files | cut -d' ' -f2)
+                    local exe_file
+                    local dll_file
+                    exe_file=$(echo "$files" | cut -d' ' -f1)
+                    dll_file=$(echo "$files" | cut -d' ' -f2)
 
                     mkdir -p "$OUTPUT_DIR"
 
@@ -339,9 +433,14 @@ download_7zz() {
                     cp "$exe_file" "$output_file"
                     print_status "Copied $(basename "$exe_file") as 7zz.exe"
 
-                    if [ -n "$dll_file" ] && [ "$dll_file" != "null" ] && [ -f "$dll_file" ]; then
+                    # download_windows guarantees a non-empty dll path on success,
+                    # so a missing file here is a hard failure.
+                    if [ -n "$dll_file" ] && [ -f "$dll_file" ]; then
                         cp "$dll_file" "${OUTPUT_DIR}/7z.dll"
                         print_status "Copied 7z.dll for complete Windows functionality"
+                    else
+                        print_error "7z.dll missing after extraction - cannot continue"
+                        return 1
                     fi
                     ;;
                 *)
@@ -494,6 +593,28 @@ fi
 if [ -z "$PLATFORM" ] || [ -z "$ARCH" ]; then
     print_status "Auto-detecting platform and architecture..."
     auto_detect_platform
+fi
+
+# Normalize the architecture for both user-supplied and auto-detected values.
+# Auto-detection already normalizes, so this is idempotent there; it primarily
+# canonicalizes user input such as aarch64/AMD64/x64.
+if [ -n "$ARCH" ]; then
+    ARCH=$(normalize_arch "$ARCH")
+fi
+
+# macOS ships only a universal2 binary. If the user explicitly requested
+# arm64/x86_64 for macOS, accept it but force universal2 and explain why.
+if [ "$PLATFORM" == "macos" ] && [ "$ARCH" != "universal2" ]; then
+    case "$ARCH" in
+        arm64|x86_64)
+            print_status "macOS provides a single universal2 binary covering both arm64 and x86_64; using universal2 instead of '$ARCH'."
+            ARCH="universal2"
+            ;;
+        *)
+            print_error "Unsupported macOS architecture: $ARCH"
+            exit 1
+            ;;
+    esac
 fi
 
 # Main execution

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -83,6 +83,32 @@ class TestPlatformInfo:
         with pytest.raises(UpdateError, match="Unsupported architecture"):
             get_platform_info()
 
+    @patch("platform.system")
+    @patch("platform.machine")
+    def test_get_platform_info_linux_aarch64(
+        self, mock_machine: Mock, mock_system: Mock
+    ) -> None:
+        """Test Linux aarch64 platform detection maps to arm64."""
+        mock_system.return_value = "Linux"
+        mock_machine.return_value = "aarch64"
+
+        platform, arch = get_platform_info()
+        assert platform == "linux"
+        assert arch == "arm64"
+
+    @patch("platform.system")
+    @patch("platform.machine")
+    def test_get_platform_info_windows_arm64(
+        self, mock_machine: Mock, mock_system: Mock
+    ) -> None:
+        """Test Windows ARM64 platform detection."""
+        mock_system.return_value = "Windows"
+        mock_machine.return_value = "ARM64"
+
+        platform, arch = get_platform_info()
+        assert platform == "windows"
+        assert arch == "arm64"
+
 
 class TestAssetName:
     """Test asset name generation."""
@@ -99,10 +125,28 @@ class TestAssetName:
         """Test Linux asset name generation."""
         assert get_asset_name("2408", "linux", "x64") == "7z2408-linux-x64.tar.xz"
 
+    def test_get_asset_name_windows_arm64(self) -> None:
+        """Test Windows arm64 asset name generation."""
+        assert get_asset_name("2408", "windows", "arm64") == "7z2408-arm64.exe"
+
+    def test_get_asset_name_linux_arm64(self) -> None:
+        """Test Linux arm64 asset name generation."""
+        assert get_asset_name("2408", "linux", "arm64") == "7z2408-linux-arm64.tar.xz"
+
     def test_get_asset_name_unsupported(self) -> None:
         """Test unsupported platform raises error."""
         with pytest.raises(UpdateError, match="Unsupported platform"):
             get_asset_name("2408", "freebsd", "x64")
+
+    def test_get_asset_name_linux_unsupported_arch(self) -> None:
+        """Test unsupported Linux architecture raises error with matching message."""
+        with pytest.raises(UpdateError, match="Unsupported Linux architecture: i386"):
+            get_asset_name("2408", "linux", "i386")
+
+    def test_get_asset_name_windows_unsupported_arch(self) -> None:
+        """Test unsupported Windows architecture raises error with matching message."""
+        with pytest.raises(UpdateError, match="Unsupported Windows architecture: arm"):
+            get_asset_name("2408", "windows", "arm")
 
 
 class TestLatestRelease:


### PR DESCRIPTION
<!--
SPDX-License-Identifier: MIT
SPDX-FileCopyrightText: 2025 py7zz contributors
-->

## Description

Adds first-class ARM64 wheel support for Linux (`aarch64`) and Windows (`win_arm64`), built and verified natively on GitHub's ARM64 runners, and clears the release-pipeline verification debt identified while reviewing PR #30.

**New wheels** (5 total per release):

| Platform | Wheel tag | Runner |
| --- | --- | --- |
| Linux x86_64 | `manylinux_2_17_x86_64.manylinux2014_x86_64` (corrected from `manylinux1`) | ubuntu-latest |
| Linux ARM64 | `manylinux_2_17_aarch64.manylinux2014_aarch64` (new) | ubuntu-24.04-arm |
| macOS | `macosx_10_9_universal2` (unchanged) | macos-latest |
| Windows x64 | `win_amd64` (unchanged) | windows-latest |
| Windows ARM64 | `win_arm64` (new, requires Python 3.11+) | windows-11-arm |

**Key changes**:

- **release.yml**: every wheel is now built, installed, and executed natively on its target architecture — no cross-build, no skipped verification. The Linux wheel tags are backed by a new glibc-floor check (measured max `GLIBC_*` requirement must not exceed 2.17). The binary smoke test and the Windows `7z.dll` presence check are now fatal. The `publish-pypi` and `github-release` jobs are untouched; PyPI-first ordering is preserved.
- **ci.yml**: sampled native ARM64 test coverage (`ubuntu-24.04-arm` x Python 3.8/3.13, `windows-11-arm` x 3.11/3.13). The duplicated ~120-line inline binary download was replaced by a call to `scripts/get_7zz.sh`, with platform/arch passed explicitly from `runner.os`/`runner.arch` (the Git Bash toolchain on `windows-11-arm` is x64-emulated, so `uname -m` would misreport the host architecture).
- **get_7zz.sh**: ARM64 download support, architecture normalization, explicit failure on unknown architectures (previously a silent x86_64 fallback), and a fatal missing-`7z.dll` check.
- **updater.py**: `get_asset_name()` no longer returns x64 asset names on ARM64 hosts; unsupported architectures raise `UpdateError`.
- **Windows ARM64 toolchain**: `actions/setup-python` provides the native ARM64 interpreter (uv has no managed windows-aarch64 Python); uv is pinned to it via `UV_PYTHON*` environment variables. Native Windows ARM64 Python starts at 3.11, which bounds the supported floor on that platform.

Upstream assets verified against the 7-Zip 26.00 release: `7z2600-linux-arm64.tar.xz` and `7z2600-arm64.exe` (a 7z SFX containing `7z.exe` + `7z.dll`, same structure as x64).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue) — `manylinux1` tag mislabeling, ARM64 asset names
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (CI download logic deduplication)

## Related Issue

Refs #30 (closed; this PR implements the feature independently with the review findings addressed)
Refs #31 (follow-up: updater.py reconnection; intentionally out of scope here)

## Testing

- [x] Tests pass locally (487 passed, 2 skipped; ruff, mypy, pre-commit all clean)
- [x] New tests added for changes (ARM64 platform detection, asset names, unsupported-architecture errors)
- [ ] Tested on Python 3.8-3.13 — covered by the CI matrix on this PR, including the new native ARM64 rows; not separately verified locally

## Checklist

- [x] PR title follows conventional commits format: `<type>(<scope>): <description>`
- [x] Code follows project style guidelines
- [x] Self-review completed (multi-pass review; all findings addressed or tracked)
- [x] Documentation updated if needed (README platform list, CHANGELOG)
- [x] No new warnings generated
- [x] All tests pass

## Screenshots (if applicable)

N/A

## Additional Notes

**Release validation plan**: after merge, push a pre-release tag (next version `a1`) to walk the full release pipeline end-to-end (5 wheels, glibc verification, PyPI publish, GitHub Release) before any stable tag.

**Known limitations / follow-ups**:
- `windows-11-arm` tool cache only ships Python 3.12+, so `setup-python` downloads 3.11 at runtime (slightly slower, functionally fine).
- `scripts/get_7zz.sh` is now 627 lines, exceeding the project's 500-line guideline (pre-existing ~540); splitting it is deliberately deferred to keep this PR reviewable.
- The in-script binary smoke test stays non-fatal by design: the script legitimately downloads cross-architecture binaries (release packaging), while both workflows enforce their own fatal native checks.
- `updater.py`'s Windows download path stores the SFX installer verbatim (pre-existing, runtime-disconnected); tracked in #31.
