### PR TITLE
feat(updater): restore source-install support via auto-download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Source Install Support**: py7zz now works when installed from source (e.g., `pip install git+...`). On first use, the version-pinned 7zz binary is automatically downloaded to `~/.cache/py7zz/` on all supported platforms (Windows x64/ARM64, macOS, Linux x86_64/ARM64). Set `PY7ZZ_NO_AUTODOWNLOAD=1` to opt out in air-gapped or CI environments.
+
+### Fixed
+- **Windows Auto-Download**: The Windows auto-download path previously stored the raw SFX installer file instead of extracting the actual `7z.exe` and `7z.dll` binaries, making the cached entry unusable. The binary is now correctly extracted before caching.
+
 ## [1.2.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ A Python wrapper for 7zz CLI tool providing cross-platform archive operations wi
 pip install py7zz
 ```
 
+PyPI wheels bundle the 7zz binary for all supported platforms — no extra download needed after `pip install`.
+
+### Install from source
+
+```bash
+pip install git+https://github.com/RxChi1d/py7zz.git
+```
+
+Source installs do not include a bundled binary. On first use, py7zz automatically downloads the version-pinned 7zz binary to `~/.cache/py7zz/` (network access required). To disable this behavior — for example in air-gapped or CI environments — set the environment variable before running:
+
+```bash
+PY7ZZ_NO_AUTODOWNLOAD=1 python your_script.py
+```
+
+Auto-download is disabled **only** when `PY7ZZ_NO_AUTODOWNLOAD` is set to an explicit truthy value: `1`, `true`, `yes`, or `on` (case-insensitive). Any other value — including unset, empty, `0`, or `false` — leaves auto-download enabled.
+
+When auto-download is disabled and no binary is available, py7zz raises a `RuntimeError` with instructions on how to supply a binary manually via the `PY7ZZ_BINARY` environment variable.
+
 For development:
 ```bash
 git clone https://github.com/rxchi1d/py7zz.git

--- a/py7zz/_download.py
+++ b/py7zz/_download.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 py7zz contributors
+"""Low-level download and extraction helpers for the auto-update tier.
+
+This module holds the platform-specific download/extract routines used by
+``py7zz.updater``. It is kept separate to keep ``updater.py`` under the
+500-line module limit. The functions here perform atomic, crash-safe binary
+placement into the per-user cache.
+"""
+
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+# Reason: import from .updater at module load is safe because updater imports
+# this module only inside function bodies, avoiding a circular import at import
+# time.
+from .updater import GITHUB_RELEASES_URL, UpdateError, get_asset_name
+
+
+def download_to_file(url: str, dest: Path) -> None:
+    """Stream-download a URL to a destination file.
+
+    Args:
+        url: Direct download URL.
+        dest: Destination path (parent must exist).
+
+    Raises:
+        UpdateError: If the download fails.
+    """
+    try:
+        response = requests.get(url, timeout=30, stream=True)
+        response.raise_for_status()
+        with open(dest, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+    except requests.RequestException as e:
+        raise UpdateError(f"Failed to download {url}: {e}") from e
+
+
+def atomic_place(source: Path, target: Path, mode: Optional[int] = None) -> None:
+    """Atomically place a file at its final cache location.
+
+    The file is staged via a temporary file in the SAME directory as the
+    target and then moved with ``os.replace``, which is atomic on both POSIX
+    and Windows.
+
+    Args:
+        source: Existing file to move into place.
+        target: Final destination path.
+        mode: Optional permission bits to apply (e.g. ``0o755``).
+
+    Raises:
+        UpdateError: If the atomic placement fails.
+    """
+    tmp_path: Optional[Path] = None
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Reason: tempfile in the same directory guarantees os.replace stays on
+        # one filesystem, keeping the swap atomic and crash-safe.
+        fd, tmp_name = tempfile.mkstemp(dir=str(target.parent))
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        shutil.move(str(source), str(tmp_path))
+        if mode is not None:
+            tmp_path.chmod(mode)
+        os.replace(str(tmp_path), str(target))
+        tmp_path = None  # Published; nothing left to clean up.
+    except OSError as e:
+        raise UpdateError(f"Failed to place binary at {target}: {e}") from e
+    finally:
+        # Reason: a failure between mkstemp and os.replace must not leave a
+        # stray staging file behind in the cache directory.
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+
+
+def extract_unix_binary(
+    release_tag: str, platform: str, arch: str, target_dir: Path, binary_path: Path
+) -> Path:
+    """Download and extract the 7zz binary from a Unix tar.xz asset.
+
+    Args:
+        release_tag: GitHub release tag in dotted form (e.g. ``"26.01"``) used
+            as the URL path segment. Asset names are normalized to the dotless
+            form (``7z2601-...``) by ``get_asset_name``.
+        platform: Platform name (``"mac"`` or ``"linux"``).
+        arch: Architecture string.
+        target_dir: Per-arch cache directory.
+        binary_path: Final path for the extracted ``7zz`` binary.
+
+    Returns:
+        Path to the extracted, executable 7zz binary.
+
+    Raises:
+        UpdateError: If download or extraction fails.
+    """
+    asset_name = get_asset_name(release_tag, platform, arch)
+    download_url = f"{GITHUB_RELEASES_URL}/{release_tag}/{asset_name}"
+
+    # Reason: per-process unique temp names let two concurrent first-use
+    # processes share the cache dir without corrupting each other's staging.
+    fd_archive, archive_name = tempfile.mkstemp(dir=str(target_dir), suffix=".tmp")
+    os.close(fd_archive)
+    fd_extract, extract_name = tempfile.mkstemp(dir=str(target_dir), suffix=".tmp")
+    os.close(fd_extract)
+    tmp_archive = Path(archive_name)
+    extracted_tmp = Path(extract_name)
+    try:
+        download_to_file(download_url, tmp_archive)
+        with tarfile.open(str(tmp_archive), "r:xz") as tar:
+            for member in tar.getmembers():
+                if member.name.endswith("/7zz") or member.name == "7zz":
+                    src = tar.extractfile(member)
+                    if src is None:
+                        raise UpdateError(
+                            f"Could not read 7zz binary from {asset_name}"
+                        )
+                    with src, open(extracted_tmp, "wb") as dst:
+                        shutil.copyfileobj(src, dst)
+                    break
+            else:
+                raise UpdateError(f"Could not find 7zz binary in {asset_name}")
+
+        # Atomic placement with executable permissions.
+        atomic_place(extracted_tmp, binary_path, mode=0o755)
+        return binary_path
+    except (tarfile.TarError, OSError) as e:
+        raise UpdateError(f"Failed to extract {asset_name}: {e}") from e
+    finally:
+        tmp_archive.unlink(missing_ok=True)
+        extracted_tmp.unlink(missing_ok=True)
+
+
+def extract_windows_binary(
+    release_tag: str, arch: str, target_dir: Path, binary_path: Path
+) -> Path:
+    """Download and extract the 7zz binary from a Windows SFX installer.
+
+    The official Windows asset ``7z{ver}-{arch}.exe`` is a 7-Zip SFX
+    installer. This function uses the version-pinned bootstrap extractor
+    ``7zr.exe`` (also a release asset) to unpack ``7z.exe`` and ``7z.dll``,
+    which are then placed as ``7zz.exe`` and ``7z.dll`` in the cache.
+
+    Args:
+        release_tag: GitHub release tag in dotted form (e.g. ``"26.01"``) used
+            as the URL path segment. The SFX asset name is normalized to the
+            dotless form (``7z2601-x64.exe``) by ``get_asset_name``.
+        arch: Architecture string (``"x64"`` or ``"arm64"``).
+        target_dir: Per-arch cache directory.
+        binary_path: Final path for ``7zz.exe``.
+
+    Returns:
+        Path to the placed ``7zz.exe`` binary.
+
+    Raises:
+        UpdateError: If download, extraction, or placement fails.
+
+    Note:
+        ``7zr.exe`` runs only on Windows, so this branch executes only at
+        runtime on Windows; there is no cross-platform concern.
+    """
+    asset_name = get_asset_name(release_tag, "windows", arch)
+    sfx_url = f"{GITHUB_RELEASES_URL}/{release_tag}/{asset_name}"
+    bootstrap_url = f"{GITHUB_RELEASES_URL}/{release_tag}/7zr.exe"
+
+    dll_final = target_dir / "7z.dll"
+
+    # Reason: per-process unique staging names + a unique extraction dir let two
+    # concurrent first-use processes share the cache dir without clobbering each
+    # other. The extraction dir lives on the same filesystem as the target, so
+    # os.replace during atomic_place stays atomic.
+    fd_boot, boot_name = tempfile.mkstemp(dir=str(target_dir), suffix=".tmp")
+    os.close(fd_boot)
+    fd_sfx, sfx_name = tempfile.mkstemp(dir=str(target_dir), suffix=".tmp")
+    os.close(fd_sfx)
+    bootstrap_path = Path(boot_name)
+    sfx_path = Path(sfx_name)
+    extract_tmpdir = tempfile.TemporaryDirectory(dir=str(target_dir))
+    extract_dir = Path(extract_tmpdir.name)
+    try:
+        # a. Download the version-pinned bootstrap extractor.
+        download_to_file(bootstrap_url, bootstrap_path)
+        # b. Download the SFX installer.
+        download_to_file(sfx_url, sfx_path)
+
+        # c. Let 7zr.exe unpack the SFX installer natively.
+        try:
+            result = subprocess.run(
+                [
+                    str(bootstrap_path),
+                    "x",
+                    str(sfx_path),
+                    "-o" + str(extract_dir),
+                    "-y",
+                ],
+                capture_output=True,
+                timeout=120,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            raise UpdateError(
+                f"Failed to run 7zr.exe to extract {asset_name}: {e}. "
+                "Install a bundled wheel with 'pip install py7zz', or set "
+                "PY7ZZ_BINARY to point at a working 7zz binary."
+            ) from e
+
+        if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace")
+            raise UpdateError(
+                f"7zr.exe failed to extract {asset_name} (exit "
+                f"{result.returncode}): {stderr}. Install a bundled wheel with "
+                "'pip install py7zz', or set PY7ZZ_BINARY to a working 7zz binary."
+            )
+
+        # d. Locate 7z.exe and 7z.dll; both are required to run.
+        exe_src = next(extract_dir.rglob("7z.exe"), None)
+        dll_src = next(extract_dir.rglob("7z.dll"), None)
+        if exe_src is None:
+            raise UpdateError(
+                f"7z.exe not found in extracted {asset_name}. Install a bundled "
+                "wheel with 'pip install py7zz', or set PY7ZZ_BINARY."
+            )
+        if dll_src is None:
+            # Reason: 7z.exe cannot run without 7z.dll, so a missing DLL is a
+            # hard failure rather than a partial success.
+            raise UpdateError(
+                f"7z.dll not found in extracted {asset_name}. Install a bundled "
+                "wheel with 'pip install py7zz', or set PY7ZZ_BINARY."
+            )
+
+        # Atomic placement: dll first, then 7z.exe -> 7zz.exe last.
+        # Reason: the exe is the publication marker, so placing the dll first
+        # guarantees a complete cache entry the moment the exe appears.
+        atomic_place(dll_src, dll_final)
+        atomic_place(exe_src, binary_path)
+        return binary_path
+    finally:
+        # e. Clean up temporary downloads and extraction directory.
+        bootstrap_path.unlink(missing_ok=True)
+        sfx_path.unlink(missing_ok=True)
+        extract_tmpdir.cleanup()

--- a/py7zz/bundled_info.py
+++ b/py7zz/bundled_info.py
@@ -9,9 +9,28 @@ supporting the new PEP 440 compliant version system.
 
 import re
 import subprocess
-from typing import Dict, Union
+from pathlib import Path
+from typing import Dict, Optional, Union
 
 from .version import get_version, get_version_type
+
+# Pinned 7zz version file shipped alongside this module (git-tracked).
+_PINNED_VERSION_FILE = Path(__file__).parent / "7zz_version.txt"
+
+
+def _read_pinned_7zz_version() -> Optional[str]:
+    """Read the pinned 7zz version from the git-tracked version file.
+
+    Returns:
+        The dotted 7zz version string (e.g. ``"26.01"``), or ``None`` if the
+        file is missing, empty, or unreadable.
+    """
+    try:
+        version = _PINNED_VERSION_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return version or None
+
 
 # Version registry containing all version information
 VERSION_REGISTRY: Dict[str, Dict[str, Union[str, None]]] = {
@@ -104,14 +123,19 @@ def get_version_info() -> Dict[str, Union[str, None]]:
     # Use hybrid approach: registry first, then auto-detection
     bundled_7zz_version = info.get("7zz_version")
     if bundled_7zz_version is None:
-        # Not in registry, try auto-detection
-        try:
-            from .core import find_7z_binary
+        # Defense-in-depth: read the pinned version file first to avoid invoking
+        # find_7z_binary (which may itself trigger an auto-download). Only fall
+        # back to binary auto-detection when the file is absent.
+        # Reason: the version file is the cheap, side-effect-free source of truth.
+        bundled_7zz_version = _read_pinned_7zz_version()
+        if bundled_7zz_version is None:
+            try:
+                from .core import find_7z_binary
 
-            binary_path = find_7z_binary()
-            bundled_7zz_version = detect_7zz_version(binary_path)
-        except Exception:
-            bundled_7zz_version = "unknown"
+                binary_path = find_7z_binary()
+                bundled_7zz_version = detect_7zz_version(binary_path)
+            except Exception:
+                bundled_7zz_version = "unknown"
 
     # Determine release type: prefer registry, otherwise derive from version string
     release_type = info.get("release_type")

--- a/py7zz/core.py
+++ b/py7zz/core.py
@@ -46,6 +46,21 @@ def get_version() -> str:
     return _get_version()
 
 
+def _autodownload_disabled() -> bool:
+    """Return whether source-install auto-download is disabled via env var.
+
+    Auto-download is disabled only when ``PY7ZZ_NO_AUTODOWNLOAD`` is set to an
+    explicit truthy value (``"1"``, ``"true"``, ``"yes"``, ``"on"``,
+    case-insensitive). Unset, empty, or falsey values (e.g. ``"0"``,
+    ``"false"``) leave auto-download enabled.
+
+    Returns:
+        ``True`` if auto-download should be skipped, otherwise ``False``.
+    """
+    value = os.environ.get("PY7ZZ_NO_AUTODOWNLOAD", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def find_7z_binary() -> str:
     """
     Find 7zz binary in order of preference:
@@ -74,15 +89,31 @@ def find_7z_binary() -> str:
     if binary_path.exists():
         return str(binary_path)
 
-    # Auto-download binary for source installs
-    # Skip auto-download to prevent circular dependency with bundled_info
-    # This feature requires manual version specification to avoid loops
+    # Tier 3: auto-download binary for source installs (pip install git+...).
+    # Reason: air-gapped/CI users can opt out to avoid a ~30s network hang.
+    # Only explicit truthy values disable auto-download, so PY7ZZ_NO_AUTODOWNLOAD=0
+    # (or "false") leaves it enabled rather than disabling on any non-empty value.
+    if not _autodownload_disabled():
+        try:
+            # Local import keeps the updater off the import path for the common
+            # bundled-wheel case and avoids any import-time circular dependency.
+            from .updater import ensure_7zz_available
+
+            cached = ensure_7zz_available()
+            if cached.exists():
+                return str(cached)
+        except Exception as e:  # noqa: BLE001
+            # Reason: any failure here (no network, extraction error) should fall
+            # through to the actionable RuntimeError below, not crash callers.
+            logger.warning(f"Auto-download of 7zz binary failed: {e}")
 
     raise RuntimeError(
         "7zz binary not found. Please either:\n"
-        "1. Ensure internet connection for auto-download (source installs)\n"
-        "2. Set PY7ZZ_BINARY environment variable to point to your 7zz binary\n"
-        "3. Check that the binary was properly bundled during build process"
+        "1. Install a bundled wheel with 'pip install py7zz' (ships 7zz)\n"
+        "2. Set the PY7ZZ_BINARY environment variable to point to your 7zz binary\n"
+        "3. Ensure internet access so py7zz can auto-download 7zz for source "
+        "installs (auto-download was attempted and failed, or was disabled via "
+        "PY7ZZ_NO_AUTODOWNLOAD)"
     )
 
 

--- a/py7zz/updater.py
+++ b/py7zz/updater.py
@@ -10,13 +10,13 @@ import json
 import os
 import platform
 import shutil
-import tarfile
-import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import requests
 from packaging.version import Version
+
+from .logging_config import get_logger
 
 # GitHub API configuration
 GITHUB_API_URL = "https://api.github.com/repos/ip7z/7zip/releases"
@@ -24,11 +24,85 @@ GITHUB_RELEASES_URL = "https://github.com/ip7z/7zip/releases/download"
 CACHE_DIR = Path.home() / ".cache" / "py7zz"
 CACHE_TIMEOUT = 24 * 60 * 60  # 24 hours in seconds
 
+# Pinned 7zz version file shipped alongside this module (git-tracked).
+PINNED_VERSION_FILE = Path(__file__).parent / "7zz_version.txt"
+
+logger = get_logger(__name__)
+
 
 class UpdateError(Exception):
     """Raised when update operations fail."""
 
     pass
+
+
+def get_pinned_7zz_version() -> str:
+    """Read the 7zz version pinned for this py7zz build.
+
+    The version is read from ``py7zz/7zz_version.txt`` (e.g. ``"26.01"``), a
+    git-tracked file shipped in both wheel and sdist distributions. This is the
+    single source of truth for the auto-download tier.
+
+    Returns:
+        Pinned 7zz version string in dotted form (e.g. ``"26.01"``).
+
+    Raises:
+        UpdateError: If the version file is missing or empty.
+
+    Note:
+        This function intentionally avoids importing ``bundled_info`` or any
+        binary-version detection. # Reason: the auto-download path must not
+        re-enter find_7z_binary, which previously caused a recursion loop
+        (find_7z_binary -> get_bundled_7zz_version -> get_version_info ->
+        detect_7zz_version -> find_7z_binary).
+    """
+    try:
+        version = PINNED_VERSION_FILE.read_text(encoding="utf-8").strip()
+    except OSError as e:
+        raise UpdateError(
+            f"Pinned 7zz version file not found at {PINNED_VERSION_FILE}: {e}"
+        ) from e
+
+    if not version:
+        raise UpdateError(
+            f"Pinned 7zz version file {PINNED_VERSION_FILE} is empty; "
+            "cannot determine which 7zz version to download."
+        )
+
+    return version
+
+
+def ensure_7zz_available() -> Path:
+    """Ensure a runnable 7zz binary is available, downloading it if needed.
+
+    This is the entry point for the auto-download tier used by source installs.
+    It reads the pinned 7zz version (dotted form, e.g. ``"26.01"``) and resolves
+    a cached binary, downloading and extracting it on a cache miss.
+
+    Returns:
+        Path to a ready-to-run 7zz binary in the per-user cache.
+
+    Raises:
+        UpdateError: If the pinned version cannot be read, or the binary cannot
+            be downloaded/extracted.
+
+    Note:
+        The pinned version is threaded through downstream helpers in its dotted
+        form. # Reason: the official ip7z/7zip release TAG used in download URLs
+        is dotted ("26.01"); asset names are dotless ("7z2601-...") and are
+        normalized only where filenames are built (get_asset_name).
+    """
+    pinned_version = get_pinned_7zz_version()
+
+    binary_path = get_cached_binary(pinned_version, auto_update=True)
+    if binary_path is None or not binary_path.exists():
+        raise UpdateError(
+            f"Failed to obtain 7zz {pinned_version} via auto-download. "
+            "Install a bundled wheel with 'pip install py7zz', or set "
+            "PY7ZZ_BINARY to point at a working 7zz binary."
+        )
+
+    return binary_path
 
 
 def get_platform_info() -> Tuple[str, str]:
@@ -95,6 +169,31 @@ def get_asset_name(version: str, platform: str, arch: str) -> str:
         raise UpdateError(f"Unsupported platform: {platform}")
 
 
+def _is_cache_complete(binary_path: Path, platform: str) -> bool:
+    """Check whether a cached binary entry is complete and runnable.
+
+    Args:
+        binary_path: Final path of the cached 7zz binary (``7zz`` or
+            ``7zz.exe``).
+        platform: Platform name (``"mac"``, ``"linux"``, ``"windows"``).
+
+    Returns:
+        ``True`` if the cache entry is complete for the platform, else
+        ``False``.
+
+    Note:
+        On Windows the binary cannot run without its sibling ``7z.dll``, so a
+        lone ``7zz.exe`` (a torn or legacy cache entry) must be treated as a
+        miss. # Reason: the exe is published last and acts as the publication
+        marker, so requiring the dll guards against exe-without-dll states.
+    """
+    if not binary_path.exists():
+        return False
+    if platform == "windows":
+        return (binary_path.parent / "7z.dll").exists()
+    return True
+
+
 def get_latest_release(use_cache: bool = True) -> Dict[str, Any]:
     """Get the latest 7zz release information from GitHub API.
 
@@ -134,106 +233,99 @@ def get_latest_release(use_cache: bool = True) -> Dict[str, Any]:
 
 
 def download_and_extract_binary(
-    version: str, platform: str, arch: str, target_dir: Path
+    release_tag: str, platform: str, arch: str, target_dir: Path
 ) -> Path:
-    """Download and extract 7zz binary for specified version and platform.
+    """Download and extract the 7zz binary for a version and platform.
 
     Args:
-        version: 7zz version string
-        platform: Platform name
-        arch: Architecture
-        target_dir: Directory to extract binary to
+        release_tag: GitHub release tag in dotted form (e.g. ``"26.01"``).
+            This is the URL path segment; asset names are normalized to the
+            dotless form internally.
+        platform: Platform name (``"mac"``, ``"linux"``, ``"windows"``).
+        arch: Architecture (``"x64"``, ``"arm64"``).
+        target_dir: Per-arch cache directory to place the binary in.
 
     Returns:
-        Path to the extracted binary.
+        Path to the ready-to-run 7zz binary.
+
+    Raises:
+        UpdateError: If the binary cannot be downloaded or extracted.
     """
-    asset_name = get_asset_name(version, platform, arch)
-    download_url = f"{GITHUB_RELEASES_URL}/{version}/{asset_name}"
+    # Reason: local import avoids a circular import, since _download imports
+    # names from this module at its top level.
+    from ._download import extract_unix_binary, extract_windows_binary
 
     binary_name = "7zz.exe" if platform == "windows" else "7zz"
     target_path = target_dir / binary_name
 
-    # Skip if already exists
-    if target_path.exists():
+    # Skip if the cache entry is complete (Windows also needs the sibling dll).
+    if _is_cache_complete(target_path, platform):
         return target_path
 
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        # Download asset
-        response = requests.get(download_url, timeout=30, stream=True)
-        response.raise_for_status()
-
-        if platform == "windows":
-            # NOTE: the official Windows .exe asset is a 7z SFX installer, not a
-            # standalone CLI binary, so saving it as 7zz.exe yields a non-working
-            # binary. This module is currently disconnected from runtime (see
-            # core.find_7z_binary); fixing the Windows extraction is tracked for
-            # the updater-reconnection work and is intentionally out of scope here.
-            with open(target_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-        else:
-            # Unix tar.xz file - extract binary
-            with tempfile.NamedTemporaryFile(
-                suffix=".tar.xz", delete=False
-            ) as tmp_file:
-                for chunk in response.iter_content(chunk_size=8192):
-                    tmp_file.write(chunk)
-                tmp_file.flush()
-
-                # Extract 7zz binary from tar.xz
-                with tarfile.open(tmp_file.name, "r:xz") as tar:
-                    # Find the 7zz binary in the archive
-                    for member in tar.getmembers():
-                        if member.name.endswith("/7zz") or member.name == "7zz":
-                            src = tar.extractfile(member)
-                            if src is not None:
-                                with src, open(target_path, "wb") as dst:
-                                    shutil.copyfileobj(src, dst)
-                            break
-                    else:
-                        raise UpdateError(f"Could not find 7zz binary in {asset_name}")
-
-                # Clean up temporary file
-                os.unlink(tmp_file.name)
-
-        # Make binary executable
-        target_path.chmod(0o755)
-
-        return target_path
-
-    except requests.RequestException as e:
-        raise UpdateError(f"Failed to download {asset_name}: {e}") from e
-    except (tarfile.TarError, OSError) as e:
-        raise UpdateError(f"Failed to extract {asset_name}: {e}") from e
+    if platform == "windows":
+        return extract_windows_binary(release_tag, arch, target_dir, target_path)
+    return extract_unix_binary(release_tag, platform, arch, target_dir, target_path)
 
 
 def get_cached_binary(version: str, auto_update: bool = True) -> Optional[Path]:
-    """Get cached binary for specified version, downloading if necessary.
+    """Get the cached 7zz binary for a version, downloading if necessary.
+
+    The cache layout is ``CACHE_DIR/{tag}/{platform}-{arch}/{binary_name}``,
+    where ``{tag}`` is the dotless, digit-only form (e.g. ``2601``) so the
+    pruning logic in ``cleanup_old_versions`` can sort versions numerically.
+    For macOS the official asset is a universal binary, so the literal arch
+    directory ``universal`` is used (``.../mac-universal/``).
 
     Args:
-        version: 7zz version string
-        auto_update: Whether to automatically download if not cached
+        version: 7zz version string, dotted (``"26.01"``) or dotless
+            (``"2601"``). The dotted form is used as the GitHub release tag for
+            download URLs; the dotless form names the cache directory.
+        auto_update: Whether to download the binary on a cache miss.
 
     Returns:
-        Path to cached binary, or None if not available and auto_update is False.
+        Path to the cached binary, or ``None`` if not available and
+        ``auto_update`` is ``False``, or if the download/cache is incomplete.
     """
     platform, arch = get_platform_info()
     binary_name = "7zz.exe" if platform == "windows" else "7zz"
 
-    version_dir = CACHE_DIR / version
-    binary_path = version_dir / binary_name
+    # Reason: the GitHub release tag is dotted ("26.01") for URLs, but the cache
+    # dir must be digit-only ("2601") so cleanup_old_versions can sort it. A
+    # dotless input is converted back to the dotted tag (the 7-Zip version
+    # format is always MAJOR.MINOR with two digits each); anything else would
+    # build a 404 download URL, so reject it early.
+    if "." in version:
+        release_tag = version
+    elif len(version) == 4 and version.isdigit():
+        release_tag = f"{version[:2]}.{version[2:]}"
+    else:
+        raise UpdateError(
+            f"Unrecognized 7zz version format: {version!r} "
+            '(expected dotted "26.01" or dotless "2601")'
+        )
+    cache_tag = release_tag.replace(".", "")
 
-    # Return cached binary if it exists
-    if binary_path.exists():
+    # Reason: the mac asset is a single universal binary covering x64 and arm64,
+    # so a fixed 'universal' arch dir avoids duplicate per-arch downloads.
+    arch_dir_name = "universal" if platform == "mac" else arch
+    arch_dir = CACHE_DIR / cache_tag / f"{platform}-{arch_dir_name}"
+    binary_path = arch_dir / binary_name
+
+    # Return cached binary only if the entry is complete for this platform.
+    if _is_cache_complete(binary_path, platform):
         return binary_path
 
-    # Download if auto_update is enabled
     if auto_update:
         try:
-            return download_and_extract_binary(version, platform, arch, version_dir)
-        except UpdateError:
+            result = download_and_extract_binary(release_tag, platform, arch, arch_dir)
+            # Reason: prune stale versions only after a successful download so a
+            # transient network failure never deletes a usable cached binary.
+            cleanup_old_versions(keep_count=3)
+            return result
+        except UpdateError as e:
+            logger.warning(f"Auto-download of 7zz {version} failed: {e}")
             return None
 
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
+# Reason: no explicit sdist include list. hatchling's default sdist ships all
+# git-tracked files (including py7zz/7zz_version.txt, tests/, CHANGELOG.md, docs,
+# and REUSE files); an explicit include list would silently drop them.
+
 [tool.hatch.build.targets.wheel]
 packages = ["py7zz"]
 # Include all files in py7zz package (including bin/ directory)

--- a/tests/test_source_install.py
+++ b/tests/test_source_install.py
@@ -1,0 +1,421 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 py7zz contributors
+"""Tests for the source-install auto-download tier (issue #31).
+
+These tests exercise the reconnected auto-download path end to end without any
+network access: ``requests`` and ``subprocess`` are mocked throughout. They
+cover the Windows SFX extraction flow, atomic binary placement, the
+``core.find_7z_binary`` tier-3 behavior, and the recursion regression guard.
+"""
+
+import io
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+import py7zz._download as dl
+from py7zz.updater import UpdateError, download_and_extract_binary
+
+
+def _fake_download_factory(file_contents: dict):
+    """Build a download_to_file stand-in that writes canned bytes per URL.
+
+    Args:
+        file_contents: Mapping of URL substring -> bytes to write at dest.
+
+    Returns:
+        A function with the same signature as ``download_to_file``.
+    """
+
+    def _fake_download(url: str, dest: Path) -> None:
+        for needle, data in file_contents.items():
+            if needle in url:
+                dest.write_bytes(data)
+                return
+        # Reason: mirror real behavior where an unknown asset 404s.
+        raise UpdateError(f"Failed to download {url}: not found")
+
+    return _fake_download
+
+
+class TestWindowsExtraction:
+    """Test the Windows SFX (7zr.exe) extraction branch."""
+
+    def _run(self, tmpdir: str, run_side_effect=None, run_return=None, drop_dll=False):
+        """Drive extract_windows_binary with mocked downloads + subprocess.
+
+        Args:
+            tmpdir: Temporary cache directory.
+            run_side_effect: Optional exception to raise from subprocess.run.
+            run_return: Optional Mock to return from subprocess.run.
+            drop_dll: If True, the simulated extraction omits 7z.dll.
+
+        Returns:
+            The (result_or_exc, mock_run) tuple for assertions.
+        """
+        target_dir = Path(tmpdir) / "2601" / "windows-x64"
+        target_dir.mkdir(parents=True)
+        binary_path = target_dir / "7zz.exe"
+
+        fake_download = _fake_download_factory(
+            {"7zr.exe": b"BOOTSTRAP", "7z2601-x64.exe": b"SFX"}
+        )
+        # Reason: pass the dotted release tag ("26.01"); the dotless asset name
+        # ("7z2601-x64.exe") is derived internally by get_asset_name.
+        release_tag = "26.01"
+
+        def fake_run(cmd, *args, **kwargs):
+            # Simulate 7zr.exe writing 7z.exe (+ 7z.dll) into the -o dir.
+            out_arg = next(a for a in cmd if a.startswith("-o"))
+            out_dir = Path(out_arg[2:])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "7z.exe").write_bytes(b"REAL7ZEXE")
+            if not drop_dll:
+                (out_dir / "7z.dll").write_bytes(b"REAL7ZDLL")
+            return run_return if run_return is not None else Mock(returncode=0)
+
+        with patch.object(dl, "download_to_file", side_effect=fake_download), patch(
+            "subprocess.run",
+            side_effect=run_side_effect if run_side_effect else fake_run,
+        ) as mock_run:
+            return (
+                dl.extract_windows_binary(release_tag, "x64", target_dir, binary_path),
+                mock_run,
+                binary_path,
+                target_dir,
+            )
+
+    def test_windows_extraction_success(self) -> None:
+        """Test a successful run places both 7zz.exe and 7z.dll."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result, mock_run, binary_path, target_dir = self._run(tmpdir)
+
+            assert result == binary_path
+            assert binary_path.exists()
+            assert binary_path.read_bytes() == b"REAL7ZEXE"
+            assert (target_dir / "7z.dll").exists()
+            assert (target_dir / "7z.dll").read_bytes() == b"REAL7ZDLL"
+
+            # 7zr.exe invoked with the documented extraction arguments. The
+            # bootstrap path is a per-process unique temp file in target_dir.
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0].endswith(".tmp")
+            assert str(target_dir) in cmd[0]
+            assert cmd[1] == "x"
+            assert "-y" in cmd
+            assert any(a.startswith("-o") for a in cmd)
+
+    def test_windows_extraction_cleans_temp_files(self) -> None:
+        """Test temp downloads and extraction dir are removed on success.
+
+        Unique per-process staging files use random mkstemp names, so assert
+        that only the published binaries (7zz.exe + 7z.dll) remain.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, _, _, target_dir = self._run(tmpdir)
+
+            remaining = sorted(p.name for p in target_dir.iterdir())
+            assert remaining == ["7z.dll", "7zz.exe"]
+
+    def test_windows_extraction_subprocess_nonzero(self) -> None:
+        """Test a non-zero 7zr.exe exit raises an actionable UpdateError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bad = Mock(returncode=2, stderr=b"boom")
+            with pytest.raises(UpdateError, match="pip install py7zz"):
+                self._run(tmpdir, run_return=bad)
+
+    def test_windows_extraction_subprocess_timeout(self) -> None:
+        """Test a subprocess timeout raises UpdateError with guidance."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            timeout = subprocess.TimeoutExpired(cmd="7zr", timeout=120)
+            with pytest.raises(UpdateError, match="PY7ZZ_BINARY"):
+                self._run(tmpdir, run_side_effect=timeout)
+
+    def test_windows_extraction_missing_dll(self) -> None:
+        """Test a missing 7z.dll after extraction is a hard failure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(UpdateError, match="7z.dll not found"):
+                self._run(tmpdir, drop_dll=True)
+
+
+class TestAtomicPlacement:
+    """Test atomic binary placement helpers."""
+
+    def test_atomic_place_uses_os_replace(self) -> None:
+        """Test final placement goes through os.replace (atomic swap)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "source"
+            src.write_bytes(b"DATA")
+            target = Path(tmpdir) / "dest" / "7zz"
+
+            with patch("py7zz._download.os.replace") as mock_replace:
+                dl.atomic_place(src, target)
+                assert mock_replace.called
+                # Final arg of os.replace is the authoritative target path.
+                assert mock_replace.call_args[0][1] == str(target)
+
+    def test_atomic_place_sets_mode(self) -> None:
+        """Test the executable mode is applied on placement."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "source"
+            src.write_bytes(b"DATA")
+            target = Path(tmpdir) / "7zz"
+
+            dl.atomic_place(src, target, mode=0o755)
+
+            assert target.exists()
+            assert (target.stat().st_mode & 0o777) == 0o755
+
+    def test_unix_extraction_happy_path_places_executable(self) -> None:
+        """Test a real tar.xz containing 7zz lands at target with mode 0o755."""
+        # Build an in-memory tar.xz fixture with a single '7zz' member.
+        buf = io.BytesIO()
+        payload = b"REAL7ZZBINARY"
+        with tarfile.open(fileobj=buf, mode="w:xz") as tar:
+            info = tarfile.TarInfo(name="7zz")
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        fixture_bytes = buf.getvalue()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir) / "2601" / "linux-x64"
+            target_dir.mkdir(parents=True)
+            binary_path = target_dir / "7zz"
+
+            def fake_download(url: str, dest: Path) -> None:
+                # Copy the in-memory fixture to the requested download dest.
+                dest.write_bytes(fixture_bytes)
+
+            with patch.object(dl, "download_to_file", side_effect=fake_download):
+                result = dl.extract_unix_binary(
+                    "26.01", "linux", "x64", target_dir, binary_path
+                )
+
+            assert result == binary_path
+            assert binary_path.exists()
+            assert binary_path.read_bytes() == payload
+            assert (binary_path.stat().st_mode & 0o777) == 0o755
+            # Only the published binary remains; temp staging is cleaned up.
+            assert sorted(p.name for p in target_dir.iterdir()) == ["7zz"]
+
+    def test_unix_extraction_no_partial_on_failure(self) -> None:
+        """Test a failed unix extraction leaves no binary at the final path."""
+        target_dir = None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir) / "2601" / "linux-x64"
+            target_dir.mkdir(parents=True)
+            binary_path = target_dir / "7zz"
+
+            # Simulate a download that writes an invalid (non-tar) archive.
+            def fake_download(url: str, dest: Path) -> None:
+                dest.write_bytes(b"not a tar archive")
+
+            with patch.object(dl, "download_to_file", side_effect=fake_download):
+                with pytest.raises(UpdateError):
+                    dl.extract_unix_binary(
+                        "2601", "linux", "x64", target_dir, binary_path
+                    )
+
+            # No partial/temp artifacts and no final binary remain.
+            assert not binary_path.exists()
+            assert list(target_dir.iterdir()) == []
+
+
+class TestDownloadDispatch:
+    """Test download_and_extract_binary routing and early-return."""
+
+    def test_early_return_when_present(self) -> None:
+        """Test an existing binary short-circuits without downloading."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir) / "2601" / "linux-x64"
+            target_dir.mkdir(parents=True)
+            existing = target_dir / "7zz"
+            existing.touch()
+
+            # If download were attempted it would raise; absence proves skip.
+            with patch.object(
+                dl, "download_to_file", side_effect=AssertionError("no download")
+            ):
+                result = download_and_extract_binary("2601", "linux", "x64", target_dir)
+            assert result == existing
+
+    def test_routes_to_windows_branch(self) -> None:
+        """Test the windows platform dispatches to extract_windows_binary."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir) / "2601" / "windows-x64"
+            sentinel = target_dir / "7zz.exe"
+
+            with patch(
+                "py7zz._download.extract_windows_binary", return_value=sentinel
+            ) as mock_win, patch("py7zz._download.extract_unix_binary") as mock_unix:
+                result = download_and_extract_binary(
+                    "2601", "windows", "x64", target_dir
+                )
+
+            assert result == sentinel
+            mock_win.assert_called_once()
+            mock_unix.assert_not_called()
+
+
+class TestCoreTier3:
+    """Test core.find_7z_binary tier-3 auto-download integration."""
+
+    def test_auto_download_success_returns_cached(self) -> None:
+        """Test a missing bundled binary triggers auto-download success."""
+        import py7zz.core as core
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cached = Path(tmpdir) / "7zz"
+            cached.touch()  # the cached download is a real, existing file
+
+            real_exists = Path.exists
+
+            def selective_exists(self):
+                # Only the auto-downloaded cached binary exists; the bundled
+                # path (and any env binary) is reported missing.
+                if str(self) == str(cached):
+                    return real_exists(self)
+                return False
+
+            with patch.dict("os.environ", {}, clear=False) as _env, patch.object(
+                core.Path, "exists", selective_exists
+            ):
+                _env.pop("PY7ZZ_NO_AUTODOWNLOAD", None)
+                _env.pop("PY7ZZ_BINARY", None)
+                with patch("py7zz.updater.ensure_7zz_available", return_value=cached):
+                    result = core.find_7z_binary()
+
+            assert result == str(cached)
+
+    def test_auto_download_failure_raises_runtime_error(self) -> None:
+        """Test auto-download failure falls through to RuntimeError."""
+        import py7zz.core as core
+
+        with patch.dict("os.environ", {}, clear=False) as _env:
+            _env.pop("PY7ZZ_NO_AUTODOWNLOAD", None)
+            _env.pop("PY7ZZ_BINARY", None)
+            with patch.object(core.Path, "exists", return_value=False), patch(
+                "py7zz.updater.ensure_7zz_available",
+                side_effect=UpdateError("no network"),
+            ):
+                with pytest.raises(RuntimeError, match="pip install py7zz"):
+                    core.find_7z_binary()
+
+    def test_opt_out_skips_auto_download(self) -> None:
+        """Test PY7ZZ_NO_AUTODOWNLOAD skips ensure_7zz_available entirely."""
+        import py7zz.core as core
+
+        with patch.dict(
+            "os.environ", {"PY7ZZ_NO_AUTODOWNLOAD": "1"}, clear=False
+        ) as _env:
+            _env.pop("PY7ZZ_BINARY", None)
+            with patch.object(core.Path, "exists", return_value=False), patch(
+                "py7zz.updater.ensure_7zz_available"
+            ) as mock_ensure:
+                with pytest.raises(RuntimeError):
+                    core.find_7z_binary()
+            # Reason: air-gapped/CI opt-out must not attempt any network call.
+            mock_ensure.assert_not_called()
+
+
+class TestAutoDownloadOptOutParsing:
+    """Test PY7ZZ_NO_AUTODOWNLOAD truthy/falsey parsing semantics (FIX E)."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("1", True),
+            ("true", True),
+            ("TRUE", True),
+            ("yes", True),
+            ("on", True),
+            ("  1  ", True),
+            ("0", False),
+            ("false", False),
+            ("no", False),
+            ("", False),
+            ("random", False),
+        ],
+    )
+    def test_disabled_only_on_explicit_truthy(self, value: str, expected: bool) -> None:
+        """Test only explicit truthy values disable auto-download."""
+        import py7zz.core as core
+
+        with patch.dict("os.environ", {"PY7ZZ_NO_AUTODOWNLOAD": value}, clear=False):
+            assert core._autodownload_disabled() is expected
+
+    def test_unset_leaves_enabled(self) -> None:
+        """Test an unset variable leaves auto-download enabled."""
+        import py7zz.core as core
+
+        with patch.dict("os.environ", {}, clear=False) as _env:
+            _env.pop("PY7ZZ_NO_AUTODOWNLOAD", None)
+            assert core._autodownload_disabled() is False
+
+    def test_falsey_value_still_attempts_autodownload(self) -> None:
+        """Test PY7ZZ_NO_AUTODOWNLOAD=0 does NOT skip ensure_7zz_available."""
+        import py7zz.core as core
+
+        with patch.dict(
+            "os.environ", {"PY7ZZ_NO_AUTODOWNLOAD": "0"}, clear=False
+        ) as _env:
+            _env.pop("PY7ZZ_BINARY", None)
+            with patch.object(core.Path, "exists", return_value=False), patch(
+                "py7zz.updater.ensure_7zz_available",
+                side_effect=UpdateError("no network"),
+            ) as mock_ensure:
+                with pytest.raises(RuntimeError):
+                    core.find_7z_binary()
+            # Reason: "0" is falsey, so auto-download must still be attempted.
+            mock_ensure.assert_called_once()
+
+
+class TestRecursionRegression:
+    """Guard against the 0fef8b6 recursion loop in source installs."""
+
+    def test_find_7z_binary_no_recursion_error(self) -> None:
+        """Test a source install with no binary fails promptly, not recursively.
+
+        Simulates: no PY7ZZ_BINARY, no bundled binary, network mocked to fail.
+        The previous bug recursed find_7z_binary -> get_bundled_7zz_version ->
+        get_version_info -> detect_7zz_version -> find_7z_binary. This asserts a
+        clean RuntimeError rather than a RecursionError.
+        """
+        import py7zz.core as core
+
+        with patch.dict("os.environ", {}, clear=False) as _env:
+            _env.pop("PY7ZZ_NO_AUTODOWNLOAD", None)
+            _env.pop("PY7ZZ_BINARY", None)
+            # No bundled binary anywhere.
+            with patch.object(core.Path, "exists", return_value=False), patch(
+                # Network failure at the lowest level keeps the real call chain
+                # intact (get_pinned_7zz_version -> get_cached_binary -> ...).
+                "py7zz._download.download_to_file",
+                side_effect=UpdateError("network unreachable"),
+            ), patch("py7zz.updater.cleanup_old_versions"):
+                try:
+                    core.find_7z_binary()
+                except RecursionError:  # pragma: no cover - regression guard
+                    pytest.fail("find_7z_binary recursed (issue #31 regression)")
+                except RuntimeError as e:
+                    assert "pip install py7zz" in str(e)
+
+    def test_get_version_info_uses_pinned_file_no_recursion(self) -> None:
+        """Test bundled_info fallback reads the pinned file without recursing."""
+        from py7zz import bundled_info
+
+        # Force the registry-miss fallback branch.
+        with patch.object(bundled_info, "get_version", return_value="9.9.9"), patch(
+            "py7zz.bundled_info._read_pinned_7zz_version", return_value="26.01"
+        ) as mock_pinned, patch(
+            "py7zz.core.find_7z_binary",
+            side_effect=AssertionError("must not call find_7z_binary"),
+        ):
+            info = bundled_info.get_version_info()
+
+        assert info["bundled_7zz_version"] == "26.01"
+        mock_pinned.assert_called_once()

--- a/tests/test_source_install.py
+++ b/tests/test_source_install.py
@@ -10,6 +10,7 @@ cover the Windows SFX extraction flow, atomic binary placement, the
 
 import io
 import subprocess
+import sys
 import tarfile
 import tempfile
 from pathlib import Path
@@ -168,7 +169,10 @@ class TestAtomicPlacement:
             dl.atomic_place(src, target, mode=0o755)
 
             assert target.exists()
-            assert (target.stat().st_mode & 0o777) == 0o755
+            # Reason: Windows has no POSIX permission bits; chmod is a no-op
+            # there, so only assert the executable mode on POSIX platforms.
+            if sys.platform != "win32":
+                assert (target.stat().st_mode & 0o777) == 0o755
 
     def test_unix_extraction_happy_path_places_executable(self) -> None:
         """Test a real tar.xz containing 7zz lands at target with mode 0o755."""
@@ -198,7 +202,10 @@ class TestAtomicPlacement:
             assert result == binary_path
             assert binary_path.exists()
             assert binary_path.read_bytes() == payload
-            assert (binary_path.stat().st_mode & 0o777) == 0o755
+            # Reason: Windows has no POSIX permission bits; chmod is a no-op
+            # there, so only assert the executable mode on POSIX platforms.
+            if sys.platform != "win32":
+                assert (binary_path.stat().st_mode & 0o777) == 0o755
             # Only the published binary remains; temp staging is cleaned up.
             assert sorted(p.name for p in target_dir.iterdir()) == ["7zz"]
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -10,12 +10,17 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+import py7zz._download as dl
 from py7zz.updater import (
     UpdateError,
+    _is_cache_complete,
     check_for_updates,
+    cleanup_old_versions,
+    ensure_7zz_available,
     get_asset_name,
     get_cached_binary,
     get_latest_release,
+    get_pinned_7zz_version,
     get_platform_info,
     get_version_from_binary,
 )
@@ -232,18 +237,54 @@ class TestCachedBinary:
 
     @patch("py7zz.updater.get_platform_info")
     def test_get_cached_binary_exists(self, mock_platform: Mock) -> None:
-        """Test when cached binary exists."""
+        """Test when cached binary exists in the nested per-arch layout."""
         mock_platform.return_value = ("linux", "x64")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_dir = Path(tmpdir)
-            version_dir = cache_dir / "2408"
-            version_dir.mkdir(parents=True)
-            binary_path = version_dir / "7zz"
+            # New layout: CACHE_DIR/{version}/{platform}-{arch}/{binary}
+            arch_dir = cache_dir / "2408" / "linux-x64"
+            arch_dir.mkdir(parents=True)
+            binary_path = arch_dir / "7zz"
             binary_path.touch()
 
             with patch("py7zz.updater.CACHE_DIR", cache_dir):
                 result = get_cached_binary("2408", auto_update=False)
+                assert result == binary_path
+
+    @patch("py7zz.updater.get_platform_info")
+    def test_get_cached_binary_exists_mac_universal(self, mock_platform: Mock) -> None:
+        """Test that macOS resolves to the literal 'mac-universal' arch dir."""
+        mock_platform.return_value = ("mac", "arm64")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            # Reason: mac asset is a universal binary, so arch dir is fixed.
+            arch_dir = cache_dir / "2601" / "mac-universal"
+            arch_dir.mkdir(parents=True)
+            binary_path = arch_dir / "7zz"
+            binary_path.touch()
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                result = get_cached_binary("2601", auto_update=False)
+                assert result == binary_path
+
+    @patch("py7zz.updater.get_platform_info")
+    def test_get_cached_binary_exists_windows(self, mock_platform: Mock) -> None:
+        """Test Windows resolves to '7zz.exe' inside the windows-x64 arch dir."""
+        mock_platform.return_value = ("windows", "x64")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            arch_dir = cache_dir / "2601" / "windows-x64"
+            arch_dir.mkdir(parents=True)
+            binary_path = arch_dir / "7zz.exe"
+            binary_path.touch()
+            # Reason: a complete Windows cache entry requires the sibling dll.
+            (arch_dir / "7z.dll").touch()
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                result = get_cached_binary("2601", auto_update=False)
                 assert result == binary_path
 
     @patch("py7zz.updater.get_platform_info")
@@ -256,6 +297,106 @@ class TestCachedBinary:
         ):
             result = get_cached_binary("2408", auto_update=False)
             assert result is None
+
+    @patch("py7zz.updater.cleanup_old_versions")
+    @patch("py7zz.updater.download_and_extract_binary")
+    @patch("py7zz.updater.get_platform_info")
+    def test_get_cached_binary_download_success(
+        self,
+        mock_platform: Mock,
+        mock_download: Mock,
+        mock_cleanup: Mock,
+    ) -> None:
+        """Test a cache miss triggers download and post-download cleanup."""
+        mock_platform.return_value = ("linux", "x64")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            arch_dir = cache_dir / "2601" / "linux-x64"
+            downloaded = arch_dir / "7zz"
+
+            def fake_download(version, platform, arch, target_dir):
+                # Simulate the download materializing the binary on a cache miss.
+                target_dir.mkdir(parents=True, exist_ok=True)
+                downloaded.touch()
+                return downloaded
+
+            mock_download.side_effect = fake_download
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                result = get_cached_binary("26.01", auto_update=True)
+
+            assert result == downloaded
+            # download_and_extract_binary receives the dotted release tag (for the
+            # URL) + the leaf dir (whose name is the dotless cache tag).
+            mock_download.assert_called_once_with("26.01", "linux", "x64", arch_dir)
+            # Reason: cleanup only runs after a successful download.
+            mock_cleanup.assert_called_once_with(keep_count=3)
+
+    @patch("py7zz.updater.cleanup_old_versions")
+    @patch("py7zz.updater.download_and_extract_binary")
+    @patch("py7zz.updater.get_platform_info")
+    def test_get_cached_binary_dotless_input_normalized_to_dotted_tag(
+        self,
+        mock_platform: Mock,
+        mock_download: Mock,
+        mock_cleanup: Mock,
+    ) -> None:
+        """Test a dotless version input is converted back to the dotted tag."""
+        mock_platform.return_value = ("linux", "x64")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            arch_dir = cache_dir / "2601" / "linux-x64"
+            downloaded = arch_dir / "7zz"
+
+            def fake_download(version, platform, arch, target_dir):
+                target_dir.mkdir(parents=True, exist_ok=True)
+                downloaded.touch()
+                return downloaded
+
+            mock_download.side_effect = fake_download
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                result = get_cached_binary("2601", auto_update=True)
+
+            assert result == downloaded
+            # Reason: a dotless input must still yield the dotted release tag,
+            # otherwise the download URL would 404.
+            mock_download.assert_called_once_with("26.01", "linux", "x64", arch_dir)
+
+    @patch("py7zz.updater.get_platform_info")
+    def test_get_cached_binary_rejects_unrecognized_version_format(
+        self, mock_platform: Mock
+    ) -> None:
+        """Test an unparseable version string raises UpdateError early."""
+        mock_platform.return_value = ("linux", "x64")
+
+        for bad_version in ("26011", "abc", ""):
+            with pytest.raises(UpdateError, match="Unrecognized 7zz version"):
+                get_cached_binary(bad_version)
+
+    @patch("py7zz.updater.cleanup_old_versions")
+    @patch("py7zz.updater.download_and_extract_binary")
+    @patch("py7zz.updater.get_platform_info")
+    def test_get_cached_binary_download_failure_returns_none(
+        self,
+        mock_platform: Mock,
+        mock_download: Mock,
+        mock_cleanup: Mock,
+    ) -> None:
+        """Test a failed download returns None and skips cleanup."""
+        mock_platform.return_value = ("linux", "x64")
+        mock_download.side_effect = UpdateError("network down")
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "py7zz.updater.CACHE_DIR", Path(tmpdir)
+        ):
+            result = get_cached_binary("2601", auto_update=True)
+
+        assert result is None
+        # Reason: a transient failure must never delete usable cached binaries.
+        mock_cleanup.assert_not_called()
 
 
 class TestVersionFromBinary:
@@ -288,3 +429,232 @@ class TestVersionFromBinary:
 
         result = get_version_from_binary(Path("/fake/path/7zz"))
         assert result is None
+
+
+class TestPinnedVersion:
+    """Test reading the pinned 7zz version file (auto-download source of truth)."""
+
+    def test_get_pinned_7zz_version_reads_packaged_file(self) -> None:
+        """Test the real packaged 7zz_version.txt is read and dotted."""
+        version = get_pinned_7zz_version()
+        # The shipped file currently pins 26.01; assert the dotted shape.
+        assert isinstance(version, str)
+        assert "." in version
+        # Sanity: it should normalize to a digit-only tag form.
+        assert version.replace(".", "").isdigit()
+
+    def test_get_pinned_7zz_version_missing_file(self) -> None:
+        """Test a missing version file raises UpdateError."""
+        fake = Path("/nonexistent/py7zz/7zz_version.txt")
+        with patch("py7zz.updater.PINNED_VERSION_FILE", fake), pytest.raises(
+            UpdateError, match="not found"
+        ):
+            get_pinned_7zz_version()
+
+    def test_get_pinned_7zz_version_empty_file(self) -> None:
+        """Test an empty version file raises UpdateError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty = Path(tmpdir) / "7zz_version.txt"
+            empty.write_text("   \n", encoding="utf-8")
+            with patch("py7zz.updater.PINNED_VERSION_FILE", empty), pytest.raises(
+                UpdateError, match="empty"
+            ):
+                get_pinned_7zz_version()
+
+
+class TestEnsureAvailable:
+    """Test the auto-download entry point used by source installs."""
+
+    @patch("py7zz.updater.get_cached_binary")
+    @patch("py7zz.updater.get_pinned_7zz_version")
+    def test_ensure_passes_dotted_version(
+        self, mock_pinned: Mock, mock_cached: Mock
+    ) -> None:
+        """Test the dotted release tag is threaded through to get_cached_binary."""
+        mock_pinned.return_value = "26.01"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            binary = Path(tmpdir) / "7zz"
+            binary.touch()
+            mock_cached.return_value = binary
+
+            result = ensure_7zz_available()
+
+        assert result == binary
+        # Reason: the dotted form is the GitHub release tag for download URLs;
+        # normalization to the dotless cache tag happens inside get_cached_binary.
+        mock_cached.assert_called_once_with("26.01", auto_update=True)
+
+    @patch("py7zz.updater.get_cached_binary")
+    @patch("py7zz.updater.get_pinned_7zz_version")
+    def test_ensure_none_result_raises(
+        self, mock_pinned: Mock, mock_cached: Mock
+    ) -> None:
+        """Test a None cache result is converted to a UpdateError."""
+        mock_pinned.return_value = "26.01"
+        mock_cached.return_value = None
+
+        with pytest.raises(UpdateError, match="auto-download"):
+            ensure_7zz_available()
+
+    @patch("py7zz.updater.get_cached_binary")
+    @patch("py7zz.updater.get_pinned_7zz_version")
+    def test_ensure_missing_file_result_raises(
+        self, mock_pinned: Mock, mock_cached: Mock
+    ) -> None:
+        """Test a returned path that does not exist raises UpdateError."""
+        mock_pinned.return_value = "26.01"
+        mock_cached.return_value = Path("/nonexistent/7zz")
+
+        with pytest.raises(UpdateError, match="auto-download"):
+            ensure_7zz_available()
+
+    @patch(
+        "py7zz.updater.get_pinned_7zz_version",
+        side_effect=UpdateError("missing version file"),
+    )
+    def test_ensure_propagates_pinned_error(self, mock_pinned: Mock) -> None:
+        """Test a pinned-version read failure propagates as UpdateError."""
+        with pytest.raises(UpdateError, match="missing version file"):
+            ensure_7zz_available()
+
+
+class TestCacheCompleteness:
+    """Test _is_cache_complete platform-specific torn-cache detection."""
+
+    def test_missing_binary_is_incomplete(self) -> None:
+        """Test a non-existent binary is reported incomplete."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            binary = Path(tmpdir) / "7zz"
+            assert _is_cache_complete(binary, "linux") is False
+
+    def test_unix_binary_present_is_complete(self) -> None:
+        """Test a present unix binary needs no sibling files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            binary = Path(tmpdir) / "7zz"
+            binary.touch()
+            assert _is_cache_complete(binary, "linux") is True
+
+    def test_windows_exe_without_dll_is_incomplete(self) -> None:
+        """Test a lone 7zz.exe (torn/legacy state) is treated as a miss."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            binary = Path(tmpdir) / "7zz.exe"
+            binary.touch()
+            # No sibling 7z.dll -> incomplete.
+            assert _is_cache_complete(binary, "windows") is False
+
+    def test_windows_exe_with_dll_is_complete(self) -> None:
+        """Test 7zz.exe plus sibling 7z.dll is a complete cache entry."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            binary = Path(tmpdir) / "7zz.exe"
+            binary.touch()
+            (Path(tmpdir) / "7z.dll").touch()
+            assert _is_cache_complete(binary, "windows") is True
+
+    @patch("py7zz.updater.get_platform_info")
+    def test_get_cached_binary_windows_exe_without_dll_is_miss(
+        self, mock_platform: Mock
+    ) -> None:
+        """Test get_cached_binary treats exe-without-dll as a cache miss."""
+        mock_platform.return_value = ("windows", "x64")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            arch_dir = cache_dir / "2601" / "windows-x64"
+            arch_dir.mkdir(parents=True)
+            (arch_dir / "7zz.exe").touch()  # exe present, dll missing
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                # auto_update=False so the incomplete cache is reported as miss.
+                result = get_cached_binary("2601", auto_update=False)
+            assert result is None
+
+
+class TestDownloadUrls:
+    """Test full download URLs use the dotted release tag and dotless assets.
+
+    Reason: the official ip7z/7zip release TAG is dotted ("26.01"); only that
+    form 302-redirects, while the dotless form 404s. Asset names are dotless.
+    These assert the EXACT full URLs to guard against a regression.
+    """
+
+    def test_unix_download_url_is_exact(self) -> None:
+        """Test the linux asset URL keeps the dotted tag, dotless asset name."""
+        captured: dict = {}
+
+        def fake_download(url: str, dest: Path) -> None:
+            captured["url"] = url
+            raise UpdateError("stop after capturing url")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir)
+            with patch.object(dl, "download_to_file", side_effect=fake_download):
+                with pytest.raises(UpdateError):
+                    dl.extract_unix_binary(
+                        "26.01", "linux", "x64", target_dir, target_dir / "7zz"
+                    )
+
+        assert (
+            captured["url"]
+            == "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz"
+        )
+
+    def test_windows_urls_are_exact(self) -> None:
+        """Test the Windows bootstrap + SFX URLs keep the dotted tag."""
+        urls: list = []
+
+        def fake_download(url: str, dest: Path) -> None:
+            urls.append(url)
+            if "7zr.exe" in url:
+                dest.write_bytes(b"BOOT")
+                return
+            # Stop before subprocess once both URLs are captured.
+            raise UpdateError("stop after capturing urls")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir)
+            with patch.object(dl, "download_to_file", side_effect=fake_download):
+                with pytest.raises(UpdateError):
+                    dl.extract_windows_binary(
+                        "26.01", "x64", target_dir, target_dir / "7zz.exe"
+                    )
+
+        assert "https://github.com/ip7z/7zip/releases/download/26.01/7zr.exe" in urls
+        assert (
+            "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-x64.exe"
+            in urls
+        )
+
+
+class TestCleanupNestedLayout:
+    """Test cleanup_old_versions with the nested per-arch cache layout."""
+
+    def test_cleanup_keeps_recent_nested_versions(self) -> None:
+        """Test old digit-named version dirs are pruned, recent ones kept."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            # Build a nested layout for several versions.
+            for ver in ("2200", "2300", "2400", "2601"):
+                leaf = cache_dir / ver / "linux-x64"
+                leaf.mkdir(parents=True)
+                (leaf / "7zz").touch()
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                cleanup_old_versions(keep_count=2)
+
+            remaining = sorted(d.name for d in cache_dir.iterdir() if d.is_dir())
+            # Keeps the two highest versions, removes the rest.
+            assert remaining == ["2400", "2601"]
+
+    def test_cleanup_ignores_non_digit_dirs(self) -> None:
+        """Test non-version directories (e.g. cache metadata) are untouched."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            (cache_dir / "2601" / "linux-x64").mkdir(parents=True)
+            (cache_dir / "not_a_version").mkdir()
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                cleanup_old_versions(keep_count=1)
+
+            assert (cache_dir / "not_a_version").exists()
+            assert (cache_dir / "2601").exists()


### PR DESCRIPTION
<!--
SPDX-License-Identifier: MIT
SPDX-FileCopyrightText: 2025 py7zz contributors
-->

## Description

Restores source-install support: `pip install git+https://github.com/RxChi1d/py7zz.git` now works on all supported platforms. On first use, py7zz auto-downloads the version-pinned 7zz binary to `~/.cache/py7zz/`.

The auto-download tier was disconnected in `0fef8b6` to break an infinite recursion (`find_7z_binary -> get_bundled_7zz_version -> get_version_info -> detect_7zz_version -> find_7z_binary`), leaving source-install users with a `RuntimeError` at first use.

**Key changes**:

- **Recursion fixed structurally**: the target 7zz version now comes from the git-tracked `py7zz/7zz_version.txt` (`get_pinned_7zz_version()`), with zero version-detection imports — no path can re-enter `find_7z_binary`. `bundled_info` gains the same pinned-file short circuit as defense in depth. A recursion regression test locks this in.
- **Tier order in `find_7z_binary`**: `PY7ZZ_BINARY` env var → bundled binary → auto-download → actionable `RuntimeError`. `PY7ZZ_NO_AUTODOWNLOAD` (`1`/`true`/`yes`/`on`) opts out for air-gapped/CI environments. Wheel users pay zero extra cost (local import, gated behind existence checks).
- **Windows path fixed**: the official `.exe` asset is a 7z SFX installer, not a standalone binary (the old code cached the raw installer as `7zz.exe`). The runtime now downloads the version-pinned `7zr.exe` bootstrap (~600 KB) from the same release, extracts `7z.exe` + `7z.dll`, and caches both; a cache hit requires both files.
- **Multi-arch cache layout**: `~/.cache/py7zz/{version}/{platform}-{arch}/` (macOS uses `mac-universal`), with atomic placement (unique temp files + `os.replace`), concurrency-safe staging, and automatic pruning to the three newest versions.
- **Downloads**: direct GitHub release-asset URLs only (dotted release tag, e.g. `.../download/26.01/7z2601-linux-x64.tar.xz`); `api.github.com` is never on the hot path (no rate-limit exposure).
- **Packaging**: removed an sdist `include` stanza that would have regressed sdist contents; hatchling defaults cover all tracked files.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue) — Windows auto-download stored the raw SFX installer; download URLs used the wrong release-tag form
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issue

Fixes #31
Refs #33 (follow-up: SHA-256 checksum pinning for runtime-downloaded binaries; deferred — consistent with the existing build-time trust model)

## Testing

- [x] Tests pass locally (538 passed, 2 skipped; ruff, mypy, pre-commit clean)
- [x] New tests added for changes (pinned-version reading, exact download URLs, nested cache layout + Windows completeness, SFX extraction via mocked `7zr`, atomic placement, opt-out env parsing, recursion regression, unix-extraction happy path with a real in-memory tar.xz)
- [ ] Tested on Python 3.8-3.13 — covered by the CI matrix on this PR; not separately verified locally

## Checklist

- [x] PR title follows conventional commits format: `<type>(<scope>): <description>`
- [x] Code follows project style guidelines
- [x] Self-review completed (multi-pass review; all verified findings addressed or tracked)
- [x] Documentation updated if needed (README install-from-source section, CHANGELOG)
- [x] No new warnings generated
- [x] All tests pass

## Screenshots (if applicable)

N/A

## Additional Notes

- All tests are network-free (requests/subprocess fully mocked); the exact-URL assertions were verified against the live release CDN (dotted tag → 302, dotless → 404).
- `py7zz/_download.py` is a new module (247 lines) keeping `updater.py` at 413 lines, both under the 500-line guideline.
- Checksum pinning for the runtime downloads is intentionally deferred to #33 to keep this PR scoped; the trust model (HTTPS + official release assets) matches the existing build-time script.
