### PR TITLE
feat(security): pin 7zz checksums and resolve code-health follow-ups

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -70,6 +70,13 @@ jobs:
 
           echo "$NEW_VERSION" > py7zz/7zz_version.txt
 
+          # Refresh the pinned SHA-256 checksums for the new version BEFORE
+          # the download verification below, which verifies against them.
+          if ! ./scripts/get_7zz.sh --refresh-checksums --version "$NEW_VERSION"; then
+            echo "::error::Failed to refresh pinned checksums for 7zz $NEW_VERSION"
+            exit 1
+          fi
+
           # Verify the new version can be downloaded (no artifacts committed; bin is gitignored)
           if ! ./scripts/get_7zz.sh --version "$NEW_VERSION"; then
             echo "::error::Failed to verify 7zz $NEW_VERSION download"
@@ -89,7 +96,9 @@ jobs:
           title: "chore: bump bundled 7zz to ${{ steps.check.outputs.new_version }}"
           commit-message: "chore: bump bundled 7zz to ${{ steps.check.outputs.new_version }}"
           labels: dependencies, automated, chore
-          add-paths: py7zz/7zz_version.txt
+          add-paths: |
+            py7zz/7zz_version.txt
+            py7zz/7zz_checksums.txt
           body: |
             ## Summary
             Detected a new 7-Zip release: **${{ steps.check.outputs.new_version }}**.
@@ -98,6 +107,7 @@ jobs:
 
             ## Changes
             - Update `py7zz/7zz_version.txt`: ${{ env.CURRENT_VERSION }} → ${{ steps.check.outputs.new_version }}
+            - Refresh `py7zz/7zz_checksums.txt` with the SHA-256 digests of the ${{ steps.check.outputs.new_version }} release assets
 
             ## Changelog Category
             - chore (dependency maintenance)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Checksum-Verified Downloads**: All 7zz binaries downloaded at runtime (source installs) and at build time are now verified against SHA-256 checksums pinned in the package before extraction or execution. A corrupted or tampered download is rejected with a clear error.
+
+### Changed
+- **Faster Repeated Operations on Source Installs**: The downloaded 7zz binary location is now resolved once per process instead of on every archive operation.
+- **Cache Hygiene**: Leftover binaries from the pre-1.3.0 cache layout under `~/.cache/py7zz/` are now cleaned up automatically.
+
+### Fixed
+- **Command-Line Pass-Through**: The `py7zz` command failed with an internal error for every operation except `--version`. All 7zz commands now pass through to the bundled binary correctly.
+
 ## [1.3.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ PyPI wheels bundle the 7zz binary for all supported platforms — no extra downl
 pip install git+https://github.com/RxChi1d/py7zz.git
 ```
 
-Source installs do not include a bundled binary. On first use, py7zz automatically downloads the version-pinned 7zz binary to `~/.cache/py7zz/` (network access required). To disable this behavior — for example in air-gapped or CI environments — set the environment variable before running:
+Source installs do not include a bundled binary. On first use, py7zz automatically downloads the version-pinned 7zz binary to `~/.cache/py7zz/` (network access required). Every download is verified against SHA-256 checksums pinned in the package before it is extracted or executed. To disable auto-download — for example in air-gapped or CI environments — set the environment variable before running:
 
 ```bash
 PY7ZZ_NO_AUTODOWNLOAD=1 python your_script.py

--- a/py7zz/7zz_checksums.txt
+++ b/py7zz/7zz_checksums.txt
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 py7zz contributors
+#
 # SHA-256 checksums for the pinned 7-Zip 26.01 release assets.
 # Source: https://github.com/ip7z/7zip/releases/tag/26.01
 # (byte-identical to the https://7-zip.org/a/ mirrors)

--- a/py7zz/7zz_checksums.txt
+++ b/py7zz/7zz_checksums.txt
@@ -1,0 +1,10 @@
+# SHA-256 checksums for the pinned 7-Zip 26.01 release assets.
+# Source: https://github.com/ip7z/7zip/releases/tag/26.01
+# (byte-identical to the https://7-zip.org/a/ mirrors)
+# Regenerate with: ./scripts/get_7zz.sh --refresh-checksums
+1fecf4e3407950939c8ffcc3e42e3039821997dea155301c75369474e5f15175  7z2601-arm64.exe
+39f8c9070c300a63c7484d9a983119ef3edf841e1ddf69f1affae29fdec5f612  7z2601-linux-arm64.tar.xz
+8ea0fc8a135e7b848e80a4116fe22dff56c8c4518dde1f43cce67f4e340b437a  7z2601-linux-x64.tar.xz
+0b6b930dbf82742e3f1014c35072a6b8b3aab183fece348e7f723675f1c5bea2  7z2601-mac.tar.xz
+d64a0468f5b5b0b0fc5b2188450bcd655b70809d97b1c4535f2884635094377d  7z2601-x64.exe
+abcf64ae1cbafddb5395e4cdd3bdc7e3e0561d54a0c6380e3dd43bdbffe519a2  7zr.exe

--- a/py7zz/_download.py
+++ b/py7zz/_download.py
@@ -8,6 +8,7 @@ This module holds the platform-specific download/extract routines used by
 placement into the per-user cache.
 """
 
+import hashlib
 import os
 import shutil
 import subprocess
@@ -17,6 +18,8 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+
+from ._pinned import read_pinned_checksums
 
 # Reason: import from .updater at module load is safe because updater imports
 # this module only inside function bodies, avoiding a circular import at import
@@ -42,6 +45,74 @@ def download_to_file(url: str, dest: Path) -> None:
                 f.write(chunk)
     except requests.RequestException as e:
         raise UpdateError(f"Failed to download {url}: {e}") from e
+
+
+def verify_checksum(path: Path, asset_name: str) -> None:
+    """Verify a downloaded file against the pinned SHA-256 checksum.
+
+    Args:
+        path: Downloaded file to verify.
+        asset_name: Release asset filename used to look up the pinned digest
+            in ``py7zz/7zz_checksums.txt``.
+
+    Raises:
+        UpdateError: If no checksum is pinned for the asset (fail closed), or
+            if the computed digest does not match the pinned one.
+
+    Note:
+        Verification happens after download and BEFORE any extraction or
+        execution of the file. # Reason: a compromised upstream asset must be
+        rejected before tarfile/7zr.exe ever touch it.
+    """
+    expected = read_pinned_checksums().get(asset_name)
+    if expected is None:
+        raise UpdateError(
+            f"No pinned SHA-256 checksum for {asset_name}; refusing to use the "
+            "downloaded file. The py7zz installation may be corrupt or the "
+            "checksum file out of sync with 7zz_version.txt."
+        )
+
+    sha256 = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                sha256.update(chunk)
+    except OSError as e:
+        raise UpdateError(
+            f"Failed to read {path} for checksum verification: {e}"
+        ) from e
+
+    actual = sha256.hexdigest()
+    if actual != expected:
+        raise UpdateError(
+            f"SHA-256 mismatch for {asset_name}: expected {expected}, got "
+            f"{actual}. The download may be corrupted or tampered with; "
+            "refusing to use it."
+        )
+
+
+def _find_extracted_member(extract_dir: Path, name: str) -> Optional[Path]:
+    """Locate an extracted installer member deterministically.
+
+    Prefers the exact top-level path (the layout official installers ship),
+    falling back to a sorted recursive search so the choice stays
+    deterministic even if a future installer layout nests or duplicates
+    files.
+
+    Args:
+        extract_dir: Directory the installer was extracted into.
+        name: Member filename to locate (e.g. ``"7z.exe"``).
+
+    Returns:
+        Path to the member, or ``None`` if not found.
+    """
+    direct = extract_dir / name
+    if direct.is_file():
+        return direct
+    # Reason: sorted() pins the selection order; bare next(rglob()) depends on
+    # filesystem iteration order and could silently pick a different copy.
+    matches = sorted(p for p in extract_dir.rglob(name) if p.is_file())
+    return matches[0] if matches else None
 
 
 def atomic_place(source: Path, target: Path, mode: Optional[int] = None) -> None:
@@ -114,6 +185,7 @@ def extract_unix_binary(
     extracted_tmp = Path(extract_name)
     try:
         download_to_file(download_url, tmp_archive)
+        verify_checksum(tmp_archive, asset_name)
         with tarfile.open(str(tmp_archive), "r:xz") as tar:
             for member in tar.getmembers():
                 if member.name.endswith("/7zz") or member.name == "7zz":
@@ -185,10 +257,14 @@ def extract_windows_binary(
     extract_tmpdir = tempfile.TemporaryDirectory(dir=str(target_dir))
     extract_dir = Path(extract_tmpdir.name)
     try:
-        # a. Download the version-pinned bootstrap extractor.
+        # a. Download and verify the version-pinned bootstrap extractor.
+        # Reason: 7zr.exe is EXECUTED below, so its checksum must be verified
+        # before it ever runs.
         download_to_file(bootstrap_url, bootstrap_path)
-        # b. Download the SFX installer.
+        verify_checksum(bootstrap_path, "7zr.exe")
+        # b. Download and verify the SFX installer.
         download_to_file(sfx_url, sfx_path)
+        verify_checksum(sfx_path, asset_name)
 
         # c. Let 7zr.exe unpack the SFX installer natively.
         try:
@@ -219,8 +295,8 @@ def extract_windows_binary(
             )
 
         # d. Locate 7z.exe and 7z.dll; both are required to run.
-        exe_src = next(extract_dir.rglob("7z.exe"), None)
-        dll_src = next(extract_dir.rglob("7z.dll"), None)
+        exe_src = _find_extracted_member(extract_dir, "7z.exe")
+        dll_src = _find_extracted_member(extract_dir, "7z.dll")
         if exe_src is None:
             raise UpdateError(
                 f"7z.exe not found in extracted {asset_name}. Install a bundled "

--- a/py7zz/_pinned.py
+++ b/py7zz/_pinned.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 py7zz contributors
+"""Readers for the pinned 7zz metadata files shipped with the package.
+
+This module is the single source of truth for reading the git-tracked
+``7zz_version.txt`` and ``7zz_checksums.txt`` files. It has no third-party
+dependencies and performs no network or subprocess work, so it is safe to
+import from any other py7zz module without circular-import or startup-cost
+concerns.
+"""
+
+from pathlib import Path
+from typing import Dict, Optional
+
+# Pinned metadata files shipped alongside this module (git-tracked, included
+# in both wheel and sdist distributions).
+PINNED_VERSION_FILE = Path(__file__).parent / "7zz_version.txt"
+PINNED_CHECKSUM_FILE = Path(__file__).parent / "7zz_checksums.txt"
+
+
+def read_pinned_7zz_version() -> Optional[str]:
+    """Read the 7zz version pinned for this py7zz build.
+
+    Returns:
+        The dotted 7zz version string (e.g. ``"26.01"``), or ``None`` if the
+        file is missing, empty, or unreadable.
+    """
+    try:
+        version = PINNED_VERSION_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return version or None
+
+
+def read_pinned_checksums() -> Dict[str, str]:
+    """Read the pinned SHA-256 checksums for downloadable 7zz release assets.
+
+    The file uses the standard ``sha256sum`` line format
+    (``<hex-digest>  <asset-name>``); blank lines and ``#`` comments are
+    ignored.
+
+    Returns:
+        Mapping of asset filename to lowercase hex SHA-256 digest. Empty if
+        the file is missing or unreadable; consumers that require checksums
+        must treat a missing entry as a hard failure (fail closed).
+    """
+    try:
+        content = PINNED_CHECKSUM_FILE.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    checksums: Dict[str, str] = {}
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        digest, asset_name = parts
+        checksums[asset_name] = digest.lower()
+    return checksums

--- a/py7zz/_platform_spec.py
+++ b/py7zz/_platform_spec.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 py7zz contributors
+"""Per-platform packaging facts for the 7zz binary.
+
+This module collects in one table everything that varies per platform about
+how the 7zz binary is named, cached, and validated, so the rules are not
+duplicated across ``core``, ``updater``, and ``_download``. It has no
+third-party dependencies and is safe to import from any other py7zz module.
+"""
+
+from typing import Dict, NamedTuple, Optional, Tuple
+
+
+class PlatformSpec(NamedTuple):
+    """Static facts about the 7zz binary on one platform.
+
+    Attributes:
+        binary_name: Filename of the main 7zz executable.
+        extra_files: Sibling files required next to the binary for it to run
+            (e.g. ``7z.dll`` on Windows). A cache entry missing any of these
+            is incomplete.
+        arch_dir: Fixed cache arch-directory override, or ``None`` to use the
+            actual architecture. macOS ships a single universal binary, so it
+            uses a fixed ``"universal"`` directory to avoid duplicate
+            per-arch downloads.
+    """
+
+    binary_name: str
+    extra_files: Tuple[str, ...]
+    arch_dir: Optional[str]
+
+
+# Keyed by 7zz release platform names (see SYSTEM_TO_PLATFORM).
+PLATFORM_SPECS: Dict[str, PlatformSpec] = {
+    "linux": PlatformSpec(binary_name="7zz", extra_files=(), arch_dir=None),
+    "mac": PlatformSpec(binary_name="7zz", extra_files=(), arch_dir="universal"),
+    "windows": PlatformSpec(
+        binary_name="7zz.exe", extra_files=("7z.dll",), arch_dir=None
+    ),
+}
+
+# Map ``platform.system().lower()`` values to 7zz release platform names.
+SYSTEM_TO_PLATFORM: Dict[str, str] = {
+    "darwin": "mac",
+    "linux": "linux",
+    "windows": "windows",
+}
+
+# Map ``platform.machine().lower()`` values to 7zz release arch names.
+MACHINE_TO_ARCH: Dict[str, str] = {
+    "x86_64": "x64",
+    "amd64": "x64",
+    "arm64": "arm64",
+    "aarch64": "arm64",
+}
+
+
+def binary_name_for_system(system: str) -> str:
+    """Return the 7zz binary filename for a ``platform.system()`` value.
+
+    Args:
+        system: Lowercased ``platform.system()`` value (e.g. ``"darwin"``).
+
+    Returns:
+        ``"7zz.exe"`` on Windows, ``"7zz"`` everywhere else (including
+        unknown systems, which keep the historical POSIX default).
+    """
+    platform_name = SYSTEM_TO_PLATFORM.get(system)
+    if platform_name is None:
+        return "7zz"
+    return PLATFORM_SPECS[platform_name].binary_name

--- a/py7zz/bundled_info.py
+++ b/py7zz/bundled_info.py
@@ -9,28 +9,10 @@ supporting the new PEP 440 compliant version system.
 
 import re
 import subprocess
-from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
+from ._pinned import read_pinned_7zz_version
 from .version import get_version, get_version_type
-
-# Pinned 7zz version file shipped alongside this module (git-tracked).
-_PINNED_VERSION_FILE = Path(__file__).parent / "7zz_version.txt"
-
-
-def _read_pinned_7zz_version() -> Optional[str]:
-    """Read the pinned 7zz version from the git-tracked version file.
-
-    Returns:
-        The dotted 7zz version string (e.g. ``"26.01"``), or ``None`` if the
-        file is missing, empty, or unreadable.
-    """
-    try:
-        version = _PINNED_VERSION_FILE.read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    return version or None
-
 
 # Version registry containing all version information
 VERSION_REGISTRY: Dict[str, Dict[str, Union[str, None]]] = {
@@ -127,7 +109,7 @@ def get_version_info() -> Dict[str, Union[str, None]]:
         # find_7z_binary (which may itself trigger an auto-download). Only fall
         # back to binary auto-detection when the file is absent.
         # Reason: the version file is the cheap, side-effect-free source of truth.
-        bundled_7zz_version = _read_pinned_7zz_version()
+        bundled_7zz_version = read_pinned_7zz_version()
         if bundled_7zz_version is None:
             try:
                 from .core import find_7z_binary

--- a/py7zz/cli.py
+++ b/py7zz/cli.py
@@ -7,6 +7,7 @@ Directly passes through to the official 7zz binary, ensuring users get complete 
 py7zz's value is in automatic binary management and providing Python API.
 """
 
+import os
 import subprocess
 import sys
 
@@ -38,18 +39,10 @@ def main() -> None:
                     # Get package version
                     pkg_ver = _get_version()
 
-                    # Get bundled 7zz version from file
-                    bundled_ver = "unknown"
-                    try:
-                        import os
+                    # Get bundled 7zz version from the shared pinned-file reader
+                    from ._pinned import read_pinned_7zz_version
 
-                        current_dir = os.path.dirname(os.path.abspath(__file__))
-                        ver_file = os.path.join(current_dir, "7zz_version.txt")
-                        if os.path.exists(ver_file):
-                            with open(ver_file) as f:
-                                bundled_ver = f.read().strip()
-                    except Exception:
-                        pass
+                    bundled_ver = read_pinned_7zz_version() or "unknown"
 
                     print(f"py7zz {pkg_ver}")
                     print(f"7zz   {bundled_ver} (bundled)")

--- a/py7zz/core.py
+++ b/py7zz/core.py
@@ -14,6 +14,8 @@ import warnings
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional, Union
 
+from ._platform_spec import binary_name_for_system
+
 # Python 3.8 compatibility - use string annotation for subprocess.CompletedProcess
 from .archive_info import ArchiveInfo
 from .config import Config, Presets
@@ -37,6 +39,12 @@ from .logging_config import get_logger
 
 # Get logger for this module
 logger = get_logger(__name__)
+
+# Memoized result of the tier-3 auto-download resolution (source installs).
+# Reason: on a warm cache, every run_7z call would otherwise re-read
+# 7zz_version.txt and re-stat the cache entry. Tiers 1 and 2 stay live so
+# PY7ZZ_BINARY changes and bundled wheels are unaffected.
+_cached_downloaded_binary: Optional[str] = None
 
 
 def get_version() -> str:
@@ -82,9 +90,7 @@ def find_7z_binary() -> str:
 
     # Platform-specific binary name but unified location
     system = platform.system().lower()
-    binary_name = "7zz.exe" if system == "windows" else "7zz"
-
-    binary_path = binaries_dir / binary_name
+    binary_path = binaries_dir / binary_name_for_system(system)
 
     if binary_path.exists():
         return str(binary_path)
@@ -93,6 +99,12 @@ def find_7z_binary() -> str:
     # Reason: air-gapped/CI users can opt out to avoid a ~30s network hang.
     # Only explicit truthy values disable auto-download, so PY7ZZ_NO_AUTODOWNLOAD=0
     # (or "false") leaves it enabled rather than disabling on any non-empty value.
+    global _cached_downloaded_binary
+    if (
+        _cached_downloaded_binary is not None
+        and Path(_cached_downloaded_binary).exists()
+    ):
+        return _cached_downloaded_binary
     if not _autodownload_disabled():
         try:
             # Local import keeps the updater off the import path for the common
@@ -101,7 +113,8 @@ def find_7z_binary() -> str:
 
             cached = ensure_7zz_available()
             if cached.exists():
-                return str(cached)
+                _cached_downloaded_binary = str(cached)
+                return _cached_downloaded_binary
         except Exception as e:  # noqa: BLE001
             # Reason: any failure here (no network, extraction error) should fall
             # through to the actionable RuntimeError below, not crash callers.

--- a/py7zz/core.py
+++ b/py7zz/core.py
@@ -100,12 +100,15 @@ def find_7z_binary() -> str:
     # Only explicit truthy values disable auto-download, so PY7ZZ_NO_AUTODOWNLOAD=0
     # (or "false") leaves it enabled rather than disabling on any non-empty value.
     global _cached_downloaded_binary
-    if (
-        _cached_downloaded_binary is not None
-        and Path(_cached_downloaded_binary).exists()
-    ):
-        return _cached_downloaded_binary
     if not _autodownload_disabled():
+        # Reason: the memo lives INSIDE the opt-out gate so setting
+        # PY7ZZ_NO_AUTODOWNLOAD mid-process disables this tier exactly as it
+        # did before memoization was added.
+        if (
+            _cached_downloaded_binary is not None
+            and Path(_cached_downloaded_binary).exists()
+        ):
+            return _cached_downloaded_binary
         try:
             # Local import keeps the updater off the import path for the common
             # bundled-wheel case and avoids any import-time circular dependency.

--- a/py7zz/updater.py
+++ b/py7zz/updater.py
@@ -1,31 +1,24 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025 py7zz contributors
-"""Auto-update module for py7zz.
+"""Auto-download module for py7zz.
 
-This module handles automatic downloading and caching of the latest 7zz binaries
-from GitHub releases, with 24-hour caching and platform-specific binary resolution.
+This module resolves the pinned 7zz binary for source installs, downloading
+and caching it from the official GitHub releases on first use. Downloads are
+verified against the SHA-256 checksums pinned in ``py7zz/7zz_checksums.txt``.
 """
 
-import json
-import os
 import platform
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional, Tuple
 
-import requests
-from packaging.version import Version
-
+from ._pinned import read_pinned_7zz_version
+from ._platform_spec import MACHINE_TO_ARCH, PLATFORM_SPECS, SYSTEM_TO_PLATFORM
 from .logging_config import get_logger
 
-# GitHub API configuration
-GITHUB_API_URL = "https://api.github.com/repos/ip7z/7zip/releases"
+# GitHub release download configuration
 GITHUB_RELEASES_URL = "https://github.com/ip7z/7zip/releases/download"
 CACHE_DIR = Path.home() / ".cache" / "py7zz"
-CACHE_TIMEOUT = 24 * 60 * 60  # 24 hours in seconds
-
-# Pinned 7zz version file shipped alongside this module (git-tracked).
-PINNED_VERSION_FILE = Path(__file__).parent / "7zz_version.txt"
 
 logger = get_logger(__name__)
 
@@ -56,19 +49,12 @@ def get_pinned_7zz_version() -> str:
         (find_7z_binary -> get_bundled_7zz_version -> get_version_info ->
         detect_7zz_version -> find_7z_binary).
     """
-    try:
-        version = PINNED_VERSION_FILE.read_text(encoding="utf-8").strip()
-    except OSError as e:
+    version = read_pinned_7zz_version()
+    if version is None:
         raise UpdateError(
-            f"Pinned 7zz version file not found at {PINNED_VERSION_FILE}: {e}"
-        ) from e
-
-    if not version:
-        raise UpdateError(
-            f"Pinned 7zz version file {PINNED_VERSION_FILE} is empty; "
-            "cannot determine which 7zz version to download."
+            f"Pinned 7zz version file at {Path(__file__).parent / '7zz_version.txt'} "
+            "is missing or empty; cannot determine which 7zz version to download."
         )
-
     return version
 
 
@@ -114,19 +100,13 @@ def get_platform_info() -> Tuple[str, str]:
     system = platform.system().lower()
     machine = platform.machine().lower()
 
-    # Map Python platform names to 7zz release naming
-    platform_map = {"darwin": "mac", "linux": "linux", "windows": "windows"}
-
-    # Map architecture names
-    arch_map = {"x86_64": "x64", "amd64": "x64", "arm64": "arm64", "aarch64": "arm64"}
-
-    if system not in platform_map:
+    if system not in SYSTEM_TO_PLATFORM:
         raise UpdateError(f"Unsupported platform: {system}")
 
-    if machine not in arch_map:
+    if machine not in MACHINE_TO_ARCH:
         raise UpdateError(f"Unsupported architecture: {machine}")
 
-    return platform_map[system], arch_map[machine]
+    return SYSTEM_TO_PLATFORM[system], MACHINE_TO_ARCH[machine]
 
 
 def get_asset_name(version: str, platform: str, arch: str) -> str:
@@ -185,51 +165,14 @@ def _is_cache_complete(binary_path: Path, platform: str) -> bool:
         On Windows the binary cannot run without its sibling ``7z.dll``, so a
         lone ``7zz.exe`` (a torn or legacy cache entry) must be treated as a
         miss. # Reason: the exe is published last and acts as the publication
-        marker, so requiring the dll guards against exe-without-dll states.
+        marker, so requiring the extra files guards against torn states.
     """
     if not binary_path.exists():
         return False
-    if platform == "windows":
-        return (binary_path.parent / "7z.dll").exists()
-    return True
-
-
-def get_latest_release(use_cache: bool = True) -> Dict[str, Any]:
-    """Get the latest 7zz release information from GitHub API.
-
-    Args:
-        use_cache: Whether to use cached release information if available.
-
-    Returns:
-        Dictionary containing release information.
-    """
-    cache_file = CACHE_DIR / "latest_release.json"
-
-    # Check cache first
-    if use_cache and cache_file.exists():
-        cache_age = cache_file.stat().st_mtime
-        if (cache_age + CACHE_TIMEOUT) > os.path.getmtime(__file__):
-            try:
-                with open(cache_file) as f:
-                    return json.load(f)  # type: ignore[no-any-return]
-            except (json.JSONDecodeError, OSError):
-                pass  # Fall through to fetch from API
-
-    # Fetch from GitHub API
-    try:
-        response = requests.get(f"{GITHUB_API_URL}/latest", timeout=10)
-        response.raise_for_status()
-        release_data = response.json()
-
-        # Cache the response
-        CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        with open(cache_file, "w") as f:
-            json.dump(release_data, f, indent=2)
-
-        return release_data  # type: ignore[no-any-return]
-
-    except requests.RequestException as e:
-        raise UpdateError(f"Failed to fetch release information: {e}") from e
+    spec = PLATFORM_SPECS.get(platform)
+    if spec is None:
+        return False
+    return all((binary_path.parent / extra).exists() for extra in spec.extra_files)
 
 
 def download_and_extract_binary(
@@ -255,8 +198,9 @@ def download_and_extract_binary(
     # names from this module at its top level.
     from ._download import extract_unix_binary, extract_windows_binary
 
-    binary_name = "7zz.exe" if platform == "windows" else "7zz"
-    target_path = target_dir / binary_name
+    if platform not in PLATFORM_SPECS:
+        raise UpdateError(f"Unsupported platform: {platform}")
+    target_path = target_dir / PLATFORM_SPECS[platform].binary_name
 
     # Skip if the cache entry is complete (Windows also needs the sibling dll).
     if _is_cache_complete(target_path, platform):
@@ -289,7 +233,7 @@ def get_cached_binary(version: str, auto_update: bool = True) -> Optional[Path]:
         ``auto_update`` is ``False``, or if the download/cache is incomplete.
     """
     platform, arch = get_platform_info()
-    binary_name = "7zz.exe" if platform == "windows" else "7zz"
+    spec = PLATFORM_SPECS[platform]
 
     # Reason: the GitHub release tag is dotted ("26.01") for URLs, but the cache
     # dir must be digit-only ("2601") so cleanup_old_versions can sort it. A
@@ -309,9 +253,9 @@ def get_cached_binary(version: str, auto_update: bool = True) -> Optional[Path]:
 
     # Reason: the mac asset is a single universal binary covering x64 and arm64,
     # so a fixed 'universal' arch dir avoids duplicate per-arch downloads.
-    arch_dir_name = "universal" if platform == "mac" else arch
+    arch_dir_name = spec.arch_dir or arch
     arch_dir = CACHE_DIR / cache_tag / f"{platform}-{arch_dir_name}"
-    binary_path = arch_dir / binary_name
+    binary_path = arch_dir / spec.binary_name
 
     # Return cached binary only if the entry is complete for this platform.
     if _is_cache_complete(binary_path, platform):
@@ -331,34 +275,14 @@ def get_cached_binary(version: str, auto_update: bool = True) -> Optional[Path]:
     return None
 
 
-def check_for_updates(current_version: Optional[str] = None) -> Optional[str]:
-    """Check if a newer version of 7zz is available.
-
-    Args:
-        current_version: Current version string, or None to always return latest
-
-    Returns:
-        Latest version string if newer than current, otherwise None.
-    """
-    try:
-        release_data = get_latest_release()
-        latest_version: str = release_data["tag_name"]
-
-        if current_version is None:
-            return latest_version
-
-        # Compare versions
-        if Version(latest_version) > Version(current_version):
-            return latest_version
-
-        return None
-
-    except (UpdateError, ValueError):
-        return None
-
-
 def cleanup_old_versions(keep_count: int = 3) -> None:
     """Clean up old cached versions, keeping only the most recent ones.
+
+    Also removes leftovers from the pre-nested cache layout, which placed the
+    binary directly at ``CACHE_DIR/{ver}/7zz`` instead of inside a
+    ``{platform}-{arch}`` subdirectory. Those flat files are unreachable by
+    the current resolution logic but would otherwise occupy keep slots
+    forever.
 
     Args:
         keep_count: Number of versions to keep
@@ -376,38 +300,17 @@ def cleanup_old_versions(keep_count: int = 3) -> None:
     for old_dir in version_dirs[keep_count:]:
         shutil.rmtree(old_dir, ignore_errors=True)
 
-
-def get_version_from_binary(binary_path: Path) -> Optional[str]:
-    """Extract version string from 7zz binary output.
-
-    Args:
-        binary_path: Path to 7zz binary
-
-    Returns:
-        Version string if extractable, otherwise None.
-    """
-    try:
-        import subprocess
-
-        result = subprocess.run(
-            [str(binary_path), "--help"], capture_output=True, text=True, timeout=5
-        )
-
-        # Parse version from help output
-        for line in result.stdout.splitlines():
-            if "7-Zip" in line and "Igor Pavlov" in line:
-                # Extract version from line like "7-Zip 24.08 (x64) : Copyright (c) 1999-2024 Igor Pavlov"
-                parts = line.split()
-                if len(parts) >= 2:
-                    version_str = parts[1]
-                    # Convert "24.08" to "2408" format
-                    try:
-                        major, minor = version_str.split(".")
-                        return f"{major}{minor.zfill(2)}"
-                    except ValueError:
-                        pass
-
-        return None
-
-    except (subprocess.SubprocessError, OSError):
-        return None
+    # Purge flat-layout orphans from kept versions. Only the known binary
+    # filenames are removed, never subdirectories, so the nested entries and
+    # any in-flight staging directories are untouched.
+    flat_orphan_names = {"7zz", "7zz.exe", "7z.dll"}
+    for version_dir in version_dirs[:keep_count]:
+        for orphan_name in flat_orphan_names:
+            orphan = version_dir / orphan_name
+            try:
+                if orphan.is_file():
+                    orphan.unlink()
+            except OSError:
+                # Reason: cache hygiene is best-effort; a locked or
+                # permission-protected file must not break binary resolution.
+                pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ packages = ["py7zz"]
 artifacts = [
     "py7zz/bin/*",
     "py7zz/7zz_version.txt",
+    "py7zz/7zz_checksums.txt",
 ]
 
 # Include license and legal files

--- a/scripts/get_7zz.sh
+++ b/scripts/get_7zz.sh
@@ -209,6 +209,9 @@ refresh_checksums() {
     local out="${tmpdir}/7zz_checksums.txt"
 
     {
+        echo "# SPDX-License-Identifier: MIT"
+        echo "# SPDX-FileCopyrightText: 2025 py7zz contributors"
+        echo "#"
         echo "# SHA-256 checksums for the pinned 7-Zip ${version} release assets."
         echo "# Source: https://github.com/ip7z/7zip/releases/tag/${version}"
         echo "# (byte-identical to the https://7-zip.org/a/ mirrors)"

--- a/scripts/get_7zz.sh
+++ b/scripts/get_7zz.sh
@@ -208,6 +208,10 @@ refresh_checksums() {
     tmpdir=$(mktemp -d)
     local out="${tmpdir}/7zz_checksums.txt"
 
+    # The literals below are written INTO the generated checksum file; the
+    # REUSE-Ignore markers stop the compliance scanner from parsing them as
+    # this script's own (then seemingly duplicated/invalid) SPDX tags.
+    # REUSE-IgnoreStart
     {
         echo "# SPDX-License-Identifier: MIT"
         echo "# SPDX-FileCopyrightText: 2025 py7zz contributors"
@@ -217,6 +221,7 @@ refresh_checksums() {
         echo "# (byte-identical to the https://7-zip.org/a/ mirrors)"
         echo "# Regenerate with: ./scripts/get_7zz.sh --refresh-checksums"
     } > "$out"
+    # REUSE-IgnoreEnd
 
     local asset digest
     for asset in "${assets[@]}"; do

--- a/scripts/get_7zz.sh
+++ b/scripts/get_7zz.sh
@@ -160,8 +160,10 @@ verify_asset_checksum() {
     fi
 
     # Exact-match lookup on the asset-name column; '#' comments are skipped.
+    # Reason: sub() strips a trailing CR so a CRLF checkout (Git Bash on
+    # Windows with autocrlf) still matches the asset name.
     local expected
-    expected=$(awk -v name="$asset_name" '$1 !~ /^#/ && $2 == name {print $1; exit}' "$CHECKSUM_FILE")
+    expected=$(awk -v name="$asset_name" '{ sub(/\r$/, "") } $1 !~ /^#/ && $2 == name { print $1; exit }' "$CHECKSUM_FILE")
     if [ -z "$expected" ]; then
         print_error "No pinned SHA-256 checksum for $asset_name in $CHECKSUM_FILE"
         print_error "Run '$0 --refresh-checksums' after bumping the 7zz version."
@@ -711,6 +713,14 @@ if [ "$CURRENT_MODE" == "$MODE_UPDATE_CONFIG" ]; then
     if detected_version=$(detect_latest_version_online); then
         print_status "Detected version: $detected_version"
         write_version_file "$detected_version"
+
+        # Reason: the download below verifies against the pinned checksums, so
+        # they must be refreshed for the new version first or verification
+        # would deterministically fail with the previous release's entries.
+        if ! refresh_checksums "$detected_version"; then
+            print_error "Checksum refresh failed for $detected_version"
+            exit 1
+        fi
 
         # Set version for download
         SEVEN_ZIP_VERSION="$detected_version"

--- a/scripts/get_7zz.sh
+++ b/scripts/get_7zz.sh
@@ -49,12 +49,17 @@ ARCH=""
 OUTPUT_DIR="py7zz/bin"
 BUILD_DIR="build"
 VERSION_FILE="py7zz/7zz_version.txt"
+CHECKSUM_FILE="py7zz/7zz_checksums.txt"
+# Canonical source for checksum refresh; byte-identical to the 7-zip.org
+# mirrors used by BASE_URL (verified), and matches the runtime download URLs.
+GITHUB_RELEASES_URL="https://github.com/ip7z/7zip/releases/download"
 
 # Modes
 MODE_DOWNLOAD="download"
 MODE_DETECT_ONLY="detect"
 MODE_UPDATE_CONFIG="update"
 MODE_GET_CURRENT="get_current"
+MODE_REFRESH_CHECKSUMS="refresh_checksums"
 CURRENT_MODE="$MODE_DOWNLOAD"
 
 # Show help
@@ -75,6 +80,8 @@ Options:
   --detect-latest        Detect latest version from website and exit (prints version)
   --get-current          Print currently configured version from file and exit
   --update-config        Detect latest version, update configuration file, and proceed
+  --refresh-checksums    Download all release assets for the configured (or
+                         --version) 7-Zip version and rewrite $CHECKSUM_FILE
 
   --help, -h             Show this help message
 
@@ -112,6 +119,119 @@ normalize_arch() {
         # Unknown value: echo back unchanged so the caller can reject it.
         *) echo "$raw" ;;
     esac
+}
+
+# Compute the SHA-256 digest of a file, portably across macOS, Linux, and
+# Git Bash on Windows.
+#
+# Args:
+#   $1: File path.
+#
+# Outputs:
+#   The lowercase hex digest on stdout.
+compute_sha256() {
+    local file="$1"
+    if command -v sha256sum &> /dev/null; then
+        sha256sum "$file" | awk '{print $1}'
+    elif command -v shasum &> /dev/null; then
+        shasum -a 256 "$file" | awk '{print $1}'
+    else
+        print_error "No SHA-256 tool found (need sha256sum or shasum)"
+        return 1
+    fi
+}
+
+# Verify a downloaded asset against the pinned checksum file.
+#
+# Fails closed: a missing checksum entry is treated as an error, the same as
+# a digest mismatch. This mirrors the runtime verification in
+# py7zz/_download.py so build-time and runtime share one trust anchor.
+#
+# Args:
+#   $1: Downloaded file path.
+#   $2: Release asset name to look up in $CHECKSUM_FILE.
+verify_asset_checksum() {
+    local file="$1"
+    local asset_name="$2"
+
+    if [ ! -f "$CHECKSUM_FILE" ]; then
+        print_error "Checksum file not found: $CHECKSUM_FILE"
+        return 1
+    fi
+
+    # Exact-match lookup on the asset-name column; '#' comments are skipped.
+    local expected
+    expected=$(awk -v name="$asset_name" '$1 !~ /^#/ && $2 == name {print $1; exit}' "$CHECKSUM_FILE")
+    if [ -z "$expected" ]; then
+        print_error "No pinned SHA-256 checksum for $asset_name in $CHECKSUM_FILE"
+        print_error "Run '$0 --refresh-checksums' after bumping the 7zz version."
+        return 1
+    fi
+
+    local actual
+    if ! actual=$(compute_sha256 "$file"); then
+        return 1
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        print_error "SHA-256 mismatch for $asset_name: expected $expected, got $actual"
+        print_error "The download may be corrupted or tampered with; refusing to use it."
+        return 1
+    fi
+
+    print_status "Checksum verified for $asset_name"
+}
+
+# Regenerate the pinned checksum file for one 7-Zip version.
+#
+# Downloads every release asset py7zz can consume (all platform binaries plus
+# the 7zr.exe runtime bootstrap) from the canonical GitHub release and writes
+# their SHA-256 digests to $CHECKSUM_FILE in sha256sum format.
+#
+# Args:
+#   $1: Dotted 7-Zip version (e.g. "26.01").
+refresh_checksums() {
+    local version="$1"
+    local dotless="${version//./}"
+    local assets=(
+        "7z${dotless}-arm64.exe"
+        "7z${dotless}-linux-arm64.tar.xz"
+        "7z${dotless}-linux-x64.tar.xz"
+        "7z${dotless}-mac.tar.xz"
+        "7z${dotless}-x64.exe"
+        "7zr.exe"
+    )
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local out="${tmpdir}/7zz_checksums.txt"
+
+    {
+        echo "# SHA-256 checksums for the pinned 7-Zip ${version} release assets."
+        echo "# Source: https://github.com/ip7z/7zip/releases/tag/${version}"
+        echo "# (byte-identical to the https://7-zip.org/a/ mirrors)"
+        echo "# Regenerate with: ./scripts/get_7zz.sh --refresh-checksums"
+    } > "$out"
+
+    local asset digest
+    for asset in "${assets[@]}"; do
+        local url="${GITHUB_RELEASES_URL}/${version}/${asset}"
+        print_status "Downloading ${asset} for checksum..."
+        if ! curl -fsSL "$url" -o "${tmpdir}/${asset}"; then
+            print_error "Failed to download $url"
+            rm -rf "$tmpdir"
+            return 1
+        fi
+        if ! digest=$(compute_sha256 "${tmpdir}/${asset}"); then
+            rm -rf "$tmpdir"
+            return 1
+        fi
+        echo "${digest}  ${asset}" >> "$out"
+    done
+
+    cp "$out" "$CHECKSUM_FILE"
+    rm -rf "$tmpdir"
+    print_success "Updated $CHECKSUM_FILE for 7-Zip $version"
 }
 
 # Auto-detect platform and architecture
@@ -218,6 +338,10 @@ download_macos_universal2() {
         return 1
     fi
 
+    if ! verify_asset_checksum "$archive" "7z${version_str}-mac.tar.xz"; then
+        return 1
+    fi
+
     print_status "Extracting macOS universal2..."
     if ! tar -xf "$archive" -C "$extract_dir"; then
         print_error "Failed to extract macOS universal2 archive"
@@ -265,6 +389,10 @@ download_linux() {
         return 1
     fi
 
+    if ! verify_asset_checksum "$archive" "7z${version_str}-linux-${asset_arch}.tar.xz"; then
+        return 1
+    fi
+
     print_status "Extracting Linux ${target_arch}..."
     if ! tar -xf "$archive" -C "$extract_dir"; then
         print_error "Failed to extract Linux archive"
@@ -309,6 +437,10 @@ download_windows() {
     print_status "Downloading Windows ${target_arch} from: $url"
     if ! curl -fsSL "$url" -o "$archive"; then
         print_error "Failed to download Windows ${target_arch} version"
+        return 1
+    fi
+
+    if ! verify_asset_checksum "$archive" "7z${version_str}-${asset_arch}.exe"; then
         return 1
     fi
 
@@ -509,6 +641,10 @@ while [[ $# -gt 0 ]]; do
             CURRENT_MODE="$MODE_UPDATE_CONFIG"
             shift
             ;;
+        --refresh-checksums)
+            CURRENT_MODE="$MODE_REFRESH_CHECKSUMS"
+            shift
+            ;;
         --output)
             OUTPUT_DIR="$2"
             shift 2
@@ -553,7 +689,23 @@ if [ "$CURRENT_MODE" == "$MODE_GET_CURRENT" ]; then
     fi
 fi
 
-# 3. Update Config Mode
+# 3. Refresh Checksums Mode
+if [ "$CURRENT_MODE" == "$MODE_REFRESH_CHECKSUMS" ]; then
+    if [ -z "$SEVEN_ZIP_VERSION" ]; then
+        if ! SEVEN_ZIP_VERSION=$(read_version_file); then
+            print_error "Configuration file not found: $VERSION_FILE (or pass --version)"
+            exit 1
+        fi
+    fi
+    if refresh_checksums "$SEVEN_ZIP_VERSION"; then
+        exit 0
+    else
+        print_error "Checksum refresh failed"
+        exit 1
+    fi
+fi
+
+# 4. Update Config Mode
 if [ "$CURRENT_MODE" == "$MODE_UPDATE_CONFIG" ]; then
     print_status "Checking for updates..."
     if detected_version=$(detect_latest_version_online); then
@@ -570,7 +722,7 @@ if [ "$CURRENT_MODE" == "$MODE_UPDATE_CONFIG" ]; then
     fi
 fi
 
-# 4. Download Mode (Default)
+# 5. Download Mode (Default)
 if [ -z "$SEVEN_ZIP_VERSION" ]; then
     # Try to read from file first
     print_status "Checking configured version..."

--- a/tests/test_checksum_pinning.py
+++ b/tests/test_checksum_pinning.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 py7zz contributors
+"""Tests for pinned SHA-256 checksum verification (issue #33).
+
+Covers the ``_pinned`` metadata readers, runtime checksum verification in
+``_download``, the deterministic SFX member selection, and consistency
+between the shipped ``7zz_version.txt`` and ``7zz_checksums.txt`` files.
+"""
+
+import hashlib
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import py7zz._download as dl
+from py7zz._pinned import (
+    PINNED_CHECKSUM_FILE,
+    read_pinned_7zz_version,
+    read_pinned_checksums,
+)
+from py7zz.updater import UpdateError
+
+
+class TestPinnedReaders:
+    """Test the shared pinned-metadata file readers."""
+
+    def test_read_pinned_version_real_file(self) -> None:
+        """Test the shipped version file parses to a dotted version."""
+        version = read_pinned_7zz_version()
+        assert version is not None
+        assert "." in version
+        assert version.replace(".", "").isdigit()
+
+    def test_read_pinned_version_missing_returns_none(self) -> None:
+        """Test a missing version file returns None (lenient reader)."""
+        fake = Path("/nonexistent/py7zz/7zz_version.txt")
+        with patch("py7zz._pinned.PINNED_VERSION_FILE", fake):
+            assert read_pinned_7zz_version() is None
+
+    def test_read_pinned_version_empty_returns_none(self) -> None:
+        """Test an empty version file returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty = Path(tmpdir) / "v.txt"
+            empty.write_text("  \n", encoding="utf-8")
+            with patch("py7zz._pinned.PINNED_VERSION_FILE", empty):
+                assert read_pinned_7zz_version() is None
+
+    def test_read_pinned_checksums_parses_sha256sum_format(self) -> None:
+        """Test comments and blanks are skipped; digests are lowercased."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f = Path(tmpdir) / "sums.txt"
+            f.write_text(
+                "# comment line\n"
+                "\n"
+                "ABCDEF0123  asset-one.tar.xz\n"
+                "deadbeef  asset-two.exe\n"
+                "malformed-line-without-name\n",
+                encoding="utf-8",
+            )
+            with patch("py7zz._pinned.PINNED_CHECKSUM_FILE", f):
+                sums = read_pinned_checksums()
+
+        assert sums == {
+            "asset-one.tar.xz": "abcdef0123",
+            "asset-two.exe": "deadbeef",
+        }
+
+    def test_read_pinned_checksums_missing_returns_empty(self) -> None:
+        """Test a missing checksum file returns an empty mapping."""
+        fake = Path("/nonexistent/py7zz/7zz_checksums.txt")
+        with patch("py7zz._pinned.PINNED_CHECKSUM_FILE", fake):
+            assert read_pinned_checksums() == {}
+
+
+class TestShippedChecksumFile:
+    """Consistency checks on the real, shipped checksum file."""
+
+    def test_checksum_file_exists_and_parses(self) -> None:
+        """Test the shipped file exists and yields valid digests."""
+        assert PINNED_CHECKSUM_FILE.exists()
+        sums = read_pinned_checksums()
+        assert sums, "shipped checksum file must not parse to empty"
+        for asset, digest in sums.items():
+            assert len(digest) == 64, f"bad digest length for {asset}"
+            assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_checksums_cover_all_pinned_version_assets(self) -> None:
+        """Test every asset py7zz can download for the pinned version is pinned.
+
+        # Reason: a version bump without a checksum refresh would brick the
+        auto-download tier (fail-closed); this catches the desync in CI.
+        """
+        version = read_pinned_7zz_version()
+        assert version is not None
+        dotless = version.replace(".", "")
+        required = {
+            f"7z{dotless}-arm64.exe",
+            f"7z{dotless}-linux-arm64.tar.xz",
+            f"7z{dotless}-linux-x64.tar.xz",
+            f"7z{dotless}-mac.tar.xz",
+            f"7z{dotless}-x64.exe",
+            "7zr.exe",
+        }
+        sums = read_pinned_checksums()
+        missing = required - set(sums)
+        assert not missing, f"checksums missing for: {sorted(missing)}"
+
+
+class TestVerifyChecksum:
+    """Test runtime SHA-256 verification of downloaded assets."""
+
+    def test_matching_checksum_passes(self) -> None:
+        """Test a file matching the pinned digest verifies silently."""
+        data = b"verified payload"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f = Path(tmpdir) / "asset"
+            f.write_bytes(data)
+            with patch(
+                "py7zz._download.read_pinned_checksums",
+                return_value={"asset.tar.xz": hashlib.sha256(data).hexdigest()},
+            ):
+                dl.verify_checksum(f, "asset.tar.xz")  # must not raise
+
+    def test_mismatched_checksum_raises(self) -> None:
+        """Test a tampered file is rejected with an UpdateError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f = Path(tmpdir) / "asset"
+            f.write_bytes(b"tampered payload")
+            with patch(
+                "py7zz._download.read_pinned_checksums",
+                return_value={"asset.tar.xz": "0" * 64},
+            ):
+                with pytest.raises(UpdateError, match="SHA-256 mismatch"):
+                    dl.verify_checksum(f, "asset.tar.xz")
+
+    def test_missing_pinned_entry_fails_closed(self) -> None:
+        """Test an asset with no pinned digest is rejected (fail closed)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f = Path(tmpdir) / "asset"
+            f.write_bytes(b"data")
+            with patch("py7zz._download.read_pinned_checksums", return_value={}):
+                with pytest.raises(UpdateError, match="No pinned SHA-256"):
+                    dl.verify_checksum(f, "asset.tar.xz")
+
+    def test_unix_extraction_rejects_tampered_archive(self) -> None:
+        """Test extract_unix_binary rejects a download whose digest mismatches.
+
+        # Reason: verification must happen BEFORE tarfile touches the bytes;
+        the final binary path must never be created.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir) / "2601" / "linux-x64"
+            target_dir.mkdir(parents=True)
+            binary_path = target_dir / "7zz"
+
+            def fake_download(url: str, dest: Path) -> None:
+                dest.write_bytes(b"evil bytes")
+
+            with patch.object(dl, "download_to_file", side_effect=fake_download), patch(
+                "py7zz._download.read_pinned_checksums",
+                return_value={"7z2601-linux-x64.tar.xz": "0" * 64},
+            ):
+                with pytest.raises(UpdateError, match="SHA-256 mismatch"):
+                    dl.extract_unix_binary(
+                        "26.01", "linux", "x64", target_dir, binary_path
+                    )
+
+            assert not binary_path.exists()
+            # No staging leftovers either.
+            assert list(target_dir.iterdir()) == []
+
+
+class TestFindExtractedMember:
+    """Test deterministic SFX member selection (issue #35 item 4)."""
+
+    def test_prefers_exact_top_level_path(self) -> None:
+        """Test a top-level member wins over nested duplicates."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "7z.exe").write_bytes(b"TOP")
+            nested = root / "sub"
+            nested.mkdir()
+            (nested / "7z.exe").write_bytes(b"NESTED")
+
+            found = dl._find_extracted_member(root, "7z.exe")
+            assert found is not None
+            assert found.read_bytes() == b"TOP"
+
+    def test_fallback_is_sorted_and_deterministic(self) -> None:
+        """Test nested-only duplicates resolve to the lexicographically first."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for sub in ("zeta", "alpha"):
+                d = root / sub
+                d.mkdir()
+                (d / "7z.exe").write_bytes(sub.encode())
+
+            found = dl._find_extracted_member(root, "7z.exe")
+            assert found is not None
+            assert found.read_bytes() == b"alpha"
+
+    def test_missing_member_returns_none(self) -> None:
+        """Test a member absent from the tree returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert dl._find_extracted_member(Path(tmpdir), "7z.exe") is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 py7zz contributors
+"""Tests for the py7zz CLI entry point."""
+
+import sys
+from unittest.mock import Mock, patch
+
+import py7zz.cli as cli
+
+
+class TestVersionCommand:
+    """Test the --version / -V fast path."""
+
+    def test_version_prints_package_and_bundled_versions(self, capsys) -> None:
+        """Test --version prints both py7zz and bundled 7zz versions."""
+        with patch.object(sys, "argv", ["py7zz", "--version"]):
+            cli.main()
+        out = capsys.readouterr().out
+        assert "py7zz " in out
+        assert "7zz   " in out
+        # The bundled version comes from the shared pinned-file reader.
+        assert "unknown" not in out
+
+    def test_version_uses_shared_pinned_reader(self, capsys) -> None:
+        """Test the version command reads via py7zz._pinned (single reader)."""
+        with patch.object(sys, "argv", ["py7zz", "-V"]), patch(
+            "py7zz._pinned.read_pinned_7zz_version", return_value="99.99"
+        ):
+            cli.main()
+        assert "7zz   99.99 (bundled)" in capsys.readouterr().out
+
+
+class TestPassThrough:
+    """Test the pass-through path to the 7zz binary.
+
+    # Reason: regression guard for the v1.3.0 bug where `import os` lived
+    inside the --version branch, making every pass-through invocation fail
+    with an unbound-local NameError before reaching the binary.
+    """
+
+    def test_posix_passthrough_execs_binary(self) -> None:
+        """Test non-version args reach os.execv with the resolved binary."""
+        captured = {}
+
+        def fake_execv(path, argv):
+            captured["path"] = path
+            captured["argv"] = argv
+
+        with patch.object(sys, "argv", ["py7zz", "i"]), patch(
+            "py7zz.cli.find_7z_binary", return_value="/fake/7zz"
+        ), patch.object(cli.os, "name", "posix"), patch.object(
+            cli.os, "execv", side_effect=fake_execv
+        ):
+            cli.main()
+
+        assert captured["path"] == "/fake/7zz"
+        assert captured["argv"] == ["/fake/7zz", "i"]
+
+    def test_windows_passthrough_uses_subprocess(self) -> None:
+        """Test the Windows branch runs the binary and exits with its code."""
+        with patch.object(sys, "argv", ["py7zz", "i"]), patch(
+            "py7zz.cli.find_7z_binary", return_value="C:\\fake\\7zz.exe"
+        ), patch.object(cli.os, "name", "nt"), patch(
+            "py7zz.cli.subprocess.run", return_value=Mock(returncode=3)
+        ) as mock_run, patch.object(cli.sys, "exit") as mock_exit:
+            cli.main()
+
+        mock_run.assert_called_once_with(["C:\\fake\\7zz.exe", "i"])
+        mock_exit.assert_called_once_with(3)
+
+    def test_passthrough_does_not_raise_unbound_os(self, capsys) -> None:
+        """Test pass-through never hits the unbound-local 'os' error."""
+        with patch.object(sys, "argv", ["py7zz", "l", "x.7z"]), patch(
+            "py7zz.cli.find_7z_binary", return_value="/fake/7zz"
+        ), patch.object(cli.os, "execv"):
+            cli.main()
+        err = capsys.readouterr().err
+        assert "local variable 'os'" not in err
+        assert "py7zz error" not in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,9 +70,12 @@ class TestPassThrough:
 
     def test_passthrough_does_not_raise_unbound_os(self, capsys) -> None:
         """Test pass-through never hits the unbound-local 'os' error."""
+        # Reason: force the POSIX branch so the test exercises the same code
+        # path on every CI platform; Windows would otherwise spawn a real
+        # subprocess against the fake binary path.
         with patch.object(sys, "argv", ["py7zz", "l", "x.7z"]), patch(
             "py7zz.cli.find_7z_binary", return_value="/fake/7zz"
-        ), patch.object(cli.os, "execv"):
+        ), patch.object(cli.os, "name", "posix"), patch.object(cli.os, "execv"):
             cli.main()
         err = capsys.readouterr().err
         assert "local variable 'os'" not in err

--- a/tests/test_source_install.py
+++ b/tests/test_source_install.py
@@ -8,6 +8,7 @@ cover the Windows SFX extraction flow, atomic binary placement, the
 ``core.find_7z_binary`` tier-3 behavior, and the recursion regression guard.
 """
 
+import hashlib
 import io
 import subprocess
 import sys
@@ -20,6 +21,35 @@ import pytest
 
 import py7zz._download as dl
 from py7zz.updater import UpdateError, download_and_extract_binary
+
+
+@pytest.fixture(autouse=True)
+def _reset_tier3_memo():
+    """Reset core's memoized tier-3 binary path between tests.
+
+    Reason: find_7z_binary memoizes the auto-downloaded path at module level;
+    leaked state would let one test's temp path satisfy another test's lookup.
+    """
+    import py7zz.core as core
+
+    core._cached_downloaded_binary = None
+    yield
+    core._cached_downloaded_binary = None
+
+
+def _checksums_for(named_bytes: dict) -> dict:
+    """Build a pinned-checksums mapping for canned asset bytes.
+
+    Args:
+        named_bytes: Mapping of asset name -> bytes the fake download writes.
+
+    Returns:
+        Mapping of asset name -> SHA-256 hex digest, suitable for patching
+        ``read_pinned_checksums`` so live verification passes in tests.
+    """
+    return {
+        name: hashlib.sha256(data).hexdigest() for name, data in named_bytes.items()
+    }
 
 
 def _fake_download_factory(file_contents: dict):
@@ -62,9 +92,8 @@ class TestWindowsExtraction:
         target_dir.mkdir(parents=True)
         binary_path = target_dir / "7zz.exe"
 
-        fake_download = _fake_download_factory(
-            {"7zr.exe": b"BOOTSTRAP", "7z2601-x64.exe": b"SFX"}
-        )
+        canned = {"7zr.exe": b"BOOTSTRAP", "7z2601-x64.exe": b"SFX"}
+        fake_download = _fake_download_factory(canned)
         # Reason: pass the dotted release tag ("26.01"); the dotless asset name
         # ("7z2601-x64.exe") is derived internally by get_asset_name.
         release_tag = "26.01"
@@ -79,7 +108,12 @@ class TestWindowsExtraction:
                 (out_dir / "7z.dll").write_bytes(b"REAL7ZDLL")
             return run_return if run_return is not None else Mock(returncode=0)
 
+        # Reason: checksum verification stays LIVE in these tests; the pinned
+        # digests are simply swapped for the canned bytes' real digests.
         with patch.object(dl, "download_to_file", side_effect=fake_download), patch(
+            "py7zz._download.read_pinned_checksums",
+            return_value=_checksums_for(canned),
+        ), patch(
             "subprocess.run",
             side_effect=run_side_effect if run_side_effect else fake_run,
         ) as mock_run:
@@ -194,7 +228,10 @@ class TestAtomicPlacement:
                 # Copy the in-memory fixture to the requested download dest.
                 dest.write_bytes(fixture_bytes)
 
-            with patch.object(dl, "download_to_file", side_effect=fake_download):
+            with patch.object(dl, "download_to_file", side_effect=fake_download), patch(
+                "py7zz._download.read_pinned_checksums",
+                return_value=_checksums_for({"7z2601-linux-x64.tar.xz": fixture_bytes}),
+            ):
                 result = dl.extract_unix_binary(
                     "26.01", "linux", "x64", target_dir, binary_path
                 )
@@ -218,10 +255,17 @@ class TestAtomicPlacement:
             binary_path = target_dir / "7zz"
 
             # Simulate a download that writes an invalid (non-tar) archive.
-            def fake_download(url: str, dest: Path) -> None:
-                dest.write_bytes(b"not a tar archive")
+            # Reason: its checksum is pinned to match so the failure exercised
+            # here is the tar-extraction error path, not checksum rejection.
+            bad_bytes = b"not a tar archive"
 
-            with patch.object(dl, "download_to_file", side_effect=fake_download):
+            def fake_download(url: str, dest: Path) -> None:
+                dest.write_bytes(bad_bytes)
+
+            with patch.object(dl, "download_to_file", side_effect=fake_download), patch(
+                "py7zz._download.read_pinned_checksums",
+                return_value=_checksums_for({"7z2601-linux-x64.tar.xz": bad_bytes}),
+            ):
                 with pytest.raises(UpdateError):
                     dl.extract_unix_binary(
                         "2601", "linux", "x64", target_dir, binary_path
@@ -311,6 +355,58 @@ class TestCoreTier3:
             ):
                 with pytest.raises(RuntimeError, match="pip install py7zz"):
                     core.find_7z_binary()
+
+    def test_auto_download_result_is_memoized(self) -> None:
+        """Test the tier-3 resolution runs once per process on a warm cache."""
+        import py7zz.core as core
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cached = Path(tmpdir) / "7zz"
+            cached.touch()
+
+            real_exists = Path.exists
+
+            def selective_exists(self):
+                if str(self) == str(cached):
+                    return real_exists(self)
+                return False
+
+            with patch.dict("os.environ", {}, clear=False) as _env, patch.object(
+                core.Path, "exists", selective_exists
+            ):
+                _env.pop("PY7ZZ_NO_AUTODOWNLOAD", None)
+                _env.pop("PY7ZZ_BINARY", None)
+                with patch(
+                    "py7zz.updater.ensure_7zz_available", return_value=cached
+                ) as mock_ensure:
+                    first = core.find_7z_binary()
+                    second = core.find_7z_binary()
+
+            assert first == second == str(cached)
+            # Reason: the second call must hit the memo, not re-resolve.
+            mock_ensure.assert_called_once()
+
+    def test_memoized_path_revalidated_when_deleted(self) -> None:
+        """Test a stale memoized path (file deleted) triggers re-resolution."""
+        import py7zz.core as core
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cached = Path(tmpdir) / "7zz"
+            cached.touch()
+            core._cached_downloaded_binary = str(cached)
+            cached.unlink()  # the memoized file vanishes
+
+            with patch.dict("os.environ", {}, clear=False) as _env:
+                _env.pop("PY7ZZ_NO_AUTODOWNLOAD", None)
+                _env.pop("PY7ZZ_BINARY", None)
+                with patch.object(core.Path, "exists", return_value=False), patch(
+                    "py7zz.updater.ensure_7zz_available",
+                    side_effect=UpdateError("no network"),
+                ) as mock_ensure:
+                    with pytest.raises(RuntimeError):
+                        core.find_7z_binary()
+            # Reason: a dead memo must fall through to a fresh resolution.
+            mock_ensure.assert_called_once()
 
     def test_opt_out_skips_auto_download(self) -> None:
         """Test PY7ZZ_NO_AUTODOWNLOAD skips ensure_7zz_available entirely."""
@@ -417,7 +513,7 @@ class TestRecursionRegression:
 
         # Force the registry-miss fallback branch.
         with patch.object(bundled_info, "get_version", return_value="9.9.9"), patch(
-            "py7zz.bundled_info._read_pinned_7zz_version", return_value="26.01"
+            "py7zz.bundled_info.read_pinned_7zz_version", return_value="26.01"
         ) as mock_pinned, patch(
             "py7zz.core.find_7z_binary",
             side_effect=AssertionError("must not call find_7z_binary"),

--- a/tests/test_source_install.py
+++ b/tests/test_source_install.py
@@ -408,6 +408,27 @@ class TestCoreTier3:
             # Reason: a dead memo must fall through to a fresh resolution.
             mock_ensure.assert_called_once()
 
+    def test_opt_out_overrides_memoized_path(self) -> None:
+        """Test PY7ZZ_NO_AUTODOWNLOAD disables tier 3 even with a warm memo.
+
+        # Reason: the memo lives inside the opt-out gate, so setting the env
+        var mid-process restores the exact pre-memoization behavior.
+        """
+        import py7zz.core as core
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cached = Path(tmpdir) / "7zz"
+            cached.touch()
+            core._cached_downloaded_binary = str(cached)
+
+            with patch.dict(
+                "os.environ", {"PY7ZZ_NO_AUTODOWNLOAD": "1"}, clear=False
+            ) as _env:
+                _env.pop("PY7ZZ_BINARY", None)
+                with patch.object(core.Path, "exists", return_value=False):
+                    with pytest.raises(RuntimeError):
+                        core.find_7z_binary()
+
     def test_opt_out_skips_auto_download(self) -> None:
         """Test PY7ZZ_NO_AUTODOWNLOAD skips ensure_7zz_available entirely."""
         import py7zz.core as core

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2,27 +2,22 @@
 # SPDX-FileCopyrightText: 2025 py7zz contributors
 """Tests for the updater module."""
 
-import json
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-import requests
 
 import py7zz._download as dl
 from py7zz.updater import (
     UpdateError,
     _is_cache_complete,
-    check_for_updates,
     cleanup_old_versions,
     ensure_7zz_available,
     get_asset_name,
     get_cached_binary,
-    get_latest_release,
     get_pinned_7zz_version,
     get_platform_info,
-    get_version_from_binary,
 )
 
 
@@ -152,84 +147,6 @@ class TestAssetName:
         """Test unsupported Windows architecture raises error with matching message."""
         with pytest.raises(UpdateError, match="Unsupported Windows architecture: arm"):
             get_asset_name("2408", "windows", "arm")
-
-
-class TestLatestRelease:
-    """Test GitHub API release fetching."""
-
-    @patch("requests.get")
-    def test_get_latest_release_success(self, mock_get: Mock) -> None:
-        """Test successful release fetching."""
-        mock_response = Mock()
-        mock_response.json.return_value = {"tag_name": "2408", "name": "7-Zip 24.08"}
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        with tempfile.TemporaryDirectory() as tmpdir, patch(
-            "py7zz.updater.CACHE_DIR", Path(tmpdir)
-        ):
-            result = get_latest_release(use_cache=False)
-            assert result["tag_name"] == "2408"
-            assert result["name"] == "7-Zip 24.08"
-
-    @patch("requests.get")
-    def test_get_latest_release_network_error(self, mock_get: Mock) -> None:
-        """Test network error handling."""
-        mock_get.side_effect = requests.RequestException("Network error")
-
-        with pytest.raises(UpdateError, match="Failed to fetch release information"):
-            get_latest_release(use_cache=False)
-
-    def test_get_latest_release_cache_hit(self) -> None:
-        """Test cache hit scenario."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            cache_dir = Path(tmpdir)
-            cache_file = cache_dir / "latest_release.json"
-
-            # Create cache file
-            cache_data = {"tag_name": "2408", "name": "7-Zip 24.08"}
-            with open(cache_file, "w") as f:
-                json.dump(cache_data, f)
-
-            with patch("py7zz.updater.CACHE_DIR", cache_dir):
-                result = get_latest_release(use_cache=True)
-                assert result["tag_name"] == "2408"
-
-
-class TestVersionChecking:
-    """Test version checking and comparison."""
-
-    @patch("py7zz.updater.get_latest_release")
-    def test_check_for_updates_newer_available(self, mock_get_release: Mock) -> None:
-        """Test when newer version is available."""
-        mock_get_release.return_value = {"tag_name": "2409"}
-
-        result = check_for_updates("2408")
-        assert result == "2409"
-
-    @patch("py7zz.updater.get_latest_release")
-    def test_check_for_updates_no_update_needed(self, mock_get_release: Mock) -> None:
-        """Test when no update is needed."""
-        mock_get_release.return_value = {"tag_name": "2408"}
-
-        result = check_for_updates("2408")
-        assert result is None
-
-    @patch("py7zz.updater.get_latest_release")
-    def test_check_for_updates_current_none(self, mock_get_release: Mock) -> None:
-        """Test when current version is None."""
-        mock_get_release.return_value = {"tag_name": "2408"}
-
-        result = check_for_updates(None)
-        assert result == "2408"
-
-    @patch("py7zz.updater.get_latest_release")
-    def test_check_for_updates_error(self, mock_get_release: Mock) -> None:
-        """Test error handling in version checking."""
-        mock_get_release.side_effect = UpdateError("API error")
-
-        result = check_for_updates("2408")
-        assert result is None
 
 
 class TestCachedBinary:
@@ -399,38 +316,6 @@ class TestCachedBinary:
         mock_cleanup.assert_not_called()
 
 
-class TestVersionFromBinary:
-    """Test version extraction from binary."""
-
-    @patch("subprocess.run")
-    def test_get_version_from_binary_success(self, mock_run: Mock) -> None:
-        """Test successful version extraction."""
-        mock_result = Mock()
-        mock_result.stdout = "7-Zip 24.08 (x64) : Copyright (c) 1999-2024 Igor Pavlov"
-        mock_run.return_value = mock_result
-
-        result = get_version_from_binary(Path("/fake/path/7zz"))
-        assert result == "2408"
-
-    @patch("subprocess.run")
-    def test_get_version_from_binary_error(self, mock_run: Mock) -> None:
-        """Test error handling in version extraction."""
-        mock_run.side_effect = OSError("Binary not found")
-
-        result = get_version_from_binary(Path("/fake/path/7zz"))
-        assert result is None
-
-    @patch("subprocess.run")
-    def test_get_version_from_binary_no_version(self, mock_run: Mock) -> None:
-        """Test when version cannot be parsed."""
-        mock_result = Mock()
-        mock_result.stdout = "Invalid output"
-        mock_run.return_value = mock_result
-
-        result = get_version_from_binary(Path("/fake/path/7zz"))
-        assert result is None
-
-
 class TestPinnedVersion:
     """Test reading the pinned 7zz version file (auto-download source of truth)."""
 
@@ -446,8 +331,8 @@ class TestPinnedVersion:
     def test_get_pinned_7zz_version_missing_file(self) -> None:
         """Test a missing version file raises UpdateError."""
         fake = Path("/nonexistent/py7zz/7zz_version.txt")
-        with patch("py7zz.updater.PINNED_VERSION_FILE", fake), pytest.raises(
-            UpdateError, match="not found"
+        with patch("py7zz._pinned.PINNED_VERSION_FILE", fake), pytest.raises(
+            UpdateError, match="missing or empty"
         ):
             get_pinned_7zz_version()
 
@@ -456,8 +341,8 @@ class TestPinnedVersion:
         with tempfile.TemporaryDirectory() as tmpdir:
             empty = Path(tmpdir) / "7zz_version.txt"
             empty.write_text("   \n", encoding="utf-8")
-            with patch("py7zz.updater.PINNED_VERSION_FILE", empty), pytest.raises(
-                UpdateError, match="empty"
+            with patch("py7zz._pinned.PINNED_VERSION_FILE", empty), pytest.raises(
+                UpdateError, match="missing or empty"
             ):
                 get_pinned_7zz_version()
 
@@ -613,7 +498,11 @@ class TestDownloadUrls:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             target_dir = Path(tmpdir)
-            with patch.object(dl, "download_to_file", side_effect=fake_download):
+            # Reason: this test asserts URL construction only, so checksum
+            # verification of the canned bytes is bypassed.
+            with patch.object(
+                dl, "download_to_file", side_effect=fake_download
+            ), patch.object(dl, "verify_checksum"):
                 with pytest.raises(UpdateError):
                     dl.extract_windows_binary(
                         "26.01", "x64", target_dir, target_dir / "7zz.exe"
@@ -658,3 +547,40 @@ class TestCleanupNestedLayout:
 
             assert (cache_dir / "not_a_version").exists()
             assert (cache_dir / "2601").exists()
+
+    def test_cleanup_purges_flat_layout_orphans(self) -> None:
+        """Test pre-nested-layout binaries directly under {ver}/ are removed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            # Old flat layout: binary directly under the version dir.
+            version_dir = cache_dir / "2601"
+            version_dir.mkdir()
+            (version_dir / "7zz").write_bytes(b"OLD")
+            (version_dir / "7z.dll").write_bytes(b"OLD")
+            # Plus a current nested entry that must survive.
+            leaf = version_dir / "linux-x64"
+            leaf.mkdir()
+            (leaf / "7zz").write_bytes(b"NEW")
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                cleanup_old_versions(keep_count=3)
+
+            # Flat orphans are gone; the nested entry is untouched.
+            assert not (version_dir / "7zz").exists()
+            assert not (version_dir / "7z.dll").exists()
+            assert (leaf / "7zz").read_bytes() == b"NEW"
+
+    def test_cleanup_does_not_remove_subdirectories(self) -> None:
+        """Test orphan purging never touches nested arch directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            version_dir = cache_dir / "2601"
+            # An arch dir whose name collides with nothing; plus a dir that
+            # happens to be named like a binary must NOT be removed.
+            (version_dir / "mac-universal").mkdir(parents=True)
+            (version_dir / "mac-universal" / "7zz").touch()
+
+            with patch("py7zz.updater.CACHE_DIR", cache_dir):
+                cleanup_old_versions(keep_count=3)
+
+            assert (version_dir / "mac-universal" / "7zz").exists()


### PR DESCRIPTION
## Summary

Implements #33 (SHA-256 checksum pinning) and consolidates all six code-health follow-ups from #35 into a single change, plus one CLI bug fix discovered during the work.

No release is required by this PR alone: the bundled binary and release pipeline outputs are unchanged. (The CLI pass-through fix does affect released behavior — see Bug fix below.)

### Checksum pinning (#33)

- New git-tracked `py7zz/7zz_checksums.txt` pins SHA-256 digests for every downloadable release asset of the pinned 7zz version (5 platform binaries + the `7zr.exe` Windows bootstrap). Shipped in both wheel and sdist.
- **Runtime**: `_download.verify_checksum()` verifies every download before extraction or execution (including `7zr.exe`, which is executed). Fails closed — a missing pinned entry is rejected the same as a mismatch.
- **Build time**: `scripts/get_7zz.sh` verifies every download against the same file (one shared trust anchor). The GitHub release assets and the 7-zip.org mirrors were verified byte-identical.
- **Maintenance**: new `./scripts/get_7zz.sh --refresh-checksums` mode regenerates the file; the check-upstream workflow refreshes checksums automatically when bumping the bundled version, and `--update-config` refreshes them before its verification download.
- A unit test asserts the checksum file covers every asset derivable from `7zz_version.txt`, catching version/checksum desync in CI.

### Code-health follow-ups (#35)

1. The three `7zz_version.txt` readers are consolidated onto `py7zz/_pinned.py`; `updater`, `bundled_info`, and `cli` share one reader.
2. The dead GitHub-API chain (`get_latest_release`, `check_for_updates`, `get_version_from_binary`, the 24h cache with its mtime bug) is removed — no production callers existed; `updater.py` no longer imports `requests`.
3. The tier-3 auto-download resolution is memoized per process (inside the `PY7ZZ_NO_AUTODOWNLOAD` gate, so opt-out semantics are unchanged); `PY7ZZ_BINARY` and bundled-wheel tiers stay live.
4. Windows SFX member selection is deterministic: exact top-level path first, sorted recursive fallback.
5. Per-platform packaging facts (binary name, required sibling files, mac `universal` arch dir) are collapsed into `py7zz/_platform_spec.py`.
6. `cleanup_old_versions` purges flat-layout cache orphans left by pre-1.3.0 installs (known binary filenames only; never directories).

### Bug fix

- `py7zz` CLI pass-through was broken in v1.3.0: `import os` lived inside the `--version` branch, so every other invocation (e.g. `py7zz l x.7z`) failed with an unbound-local error before reaching the binary. Fixed with a module-level import and covered by new regression tests.

## Review

Multi-angle review from several independent perspectives surfaced 3 actionable findings, all fixed before submission:

- CRLF checkouts (Git Bash + autocrlf) broke the awk checksum lookup — now strips trailing CR.
- `--update-config` would deterministically fail verification against the previous release's checksums — now refreshes first.
- The tier-3 memo was checked before the `PY7ZZ_NO_AUTODOWNLOAD` gate — moved inside it, with a regression test.

One reviewer suggestion was deliberately not adopted: re-verifying already-cached extracted binaries on every resolve. The pinned digests cover the downloaded archives, not the extracted binaries, and a local attacker with write access to `~/.cache` could equally modify `site-packages` — consistent with pip's own trust model, local-write attackers are out of scope. Pre-existing caches were downloaded over HTTPS from the same official source.

## Testing

- 552 passed, 2 skipped (`uv run pytest`); mypy, ruff, REUSE, and the full local CI simulation pass.
- New tests: checksum verification (match/mismatch/missing entry/tampered archive rejection), pinned-reader parsing, version-asset coverage consistency, deterministic SFX selection, memoization (warm-hit, stale-path revalidation, opt-out override), flat-orphan purge (incl. never-touches-directories), CLI pass-through regression guards.
- Shell verification on real downloads: checksum pass verified; a corrupted pinned digest hard-fails the build path; `--refresh-checksums` regenerates a byte-identical file.

Closes #33
Closes #35
